### PR TITLE
Add Searchbar Pattern/Block Styles

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -4,11 +4,31 @@ namespace WordPressdotorg\Theme\Showcase_2022;
 
 // Block files
 require_once( __DIR__ . '/src/site-screenshot/index.php' );
+require_once __DIR__ . '/inc/block-styles.php';
 
 // Filters and Actions
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
 add_filter( 'jetpack_images_get_images', __NAMESPACE__ . '\jetpack_fallback_image', 10, 3 );
 add_action( 'wp', __NAMESPACE__ . '\jetpackme_remove_rp', 20 );
 add_filter( 'jetpack_relatedposts_filter_thumbnail_size', __NAMESPACE__ . '\jetpackchange_image_size' );
+
+
+/**
+ * Enqueue scripts and styles.
+ */
+function enqueue_assets() {
+	// The parent style is registered as `wporg-parent-2021-style`, and will be loaded unless
+	// explicitly unregistered. We can load any child-theme overrides by declaring the parent
+	// stylesheet as a dependency.
+	wp_enqueue_style(
+		'wporg-showcase-2022-style',
+		get_stylesheet_directory_uri() . '/build/style/style-index.css',
+		array( 'wporg-parent-2021-style' ),
+		filemtime( __DIR__ . '/build/style/style-index.css' )
+	);
+	wp_style_add_data( 'wporg-showcase-2022-style', 'rtl', 'replace' );
+
+}
 
 /**
  * Retrieve the domain from post meta.

--- a/source/wp-content/themes/wporg-showcase-2022/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/block-styles.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Block Styles & Variations
+ *
+ * Load the CSS, JS, and register custom styles.
+ */
+
+namespace WordPressdotorg\Theme\Showcase_2022\Block_Styles;
+
+defined( 'WPINC' ) || die();
+
+const STYLE_HANDLE = 'wporg-showcase-block-styles';
+
+/**
+ * Actions and filters.
+ */
+add_action( 'init', __NAMESPACE__ . '\setup_block_styles' );
+// add_filter( 'should_load_separate_core_block_assets', '__return_false' );
+
+/**
+ * Add our custom block styles & class names.
+ */
+function setup_block_styles() {
+	register_block_style(
+		'core/search',
+		array(
+			'name'         => 'secondary-search-control',
+			'label'        => __( 'Secondary', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
+}

--- a/source/wp-content/themes/wporg-showcase-2022/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/block-styles.php
@@ -15,7 +15,6 @@ const STYLE_HANDLE = 'wporg-showcase-block-styles';
  * Actions and filters.
  */
 add_action( 'init', __NAMESPACE__ . '\setup_block_styles' );
-// add_filter( 'should_load_separate_core_block_assets', '__return_false' );
 
 /**
  * Add our custom block styles & class names.

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/secondary-search-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/secondary-search-bar.php
@@ -7,4 +7,4 @@
 
 ?>
 
-<!-- wp:search {"label":"Search","showLabel":true,"placeholder":"<?php esc_attr_e( 'Search sites...', 'wporg' ); ?>","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control"} /-->
+<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":true,"placeholder":"<?php esc_attr_e( 'Search sites...', 'wporg' ); ?>","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/secondary-search-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/secondary-search-bar.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Title: Subnav
+ * Slug: wporg-showcase-2022/secondary-search-bar
+ * Categories: wporg
+ */
+
+?>
+
+<!-- wp:search {"label":"Search","showLabel":true,"placeholder":"<?php esc_attr_e( 'Search sites...', 'wporg' ); ?>","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/secondary-search-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/secondary-search-bar.php
@@ -7,4 +7,4 @@
 
 ?>
 
-<!-- wp:search {"label":"<?php esc_attr_e( 'Search', 'wporg' ); ?>","showLabel":true,"placeholder":"<?php esc_attr_e( 'Search sites...', 'wporg' ); ?>","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control"} /-->
+<!-- wp:search {"showLabel":false,"placeholder":"<?php esc_attr_e( 'Search sites...', 'wporg' ); ?>","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"className":"is-style-secondary-search-control"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/secondary-search-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/secondary-search-bar.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Subnav
+ * Title: Secondary Search Bar
  * Slug: wporg-showcase-2022/secondary-search-bar
  * Categories: wporg
  */

--- a/source/wp-content/themes/wporg-showcase-2022/src/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/index.js
@@ -1,0 +1,2 @@
+// Noop, just imports the CSS for webpack.
+import './index.js';

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/block.json
@@ -1,0 +1,3 @@
+{
+	"script": "file:./index.js"
+}

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/index.js
@@ -1,0 +1,2 @@
+// Noop, just imports the CSS for webpack.
+import './style.scss';

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -1,0 +1,43 @@
+/*
+ * Note: only add styles here in cases where you can't achieve the style with
+ * templates or theme.json settings.
+ */
+
+/*
+ * Block styles.
+ */
+
+/*
+ * core/search.
+ */
+
+.is-style-secondary-search-control {
+	display: flex;
+	align-items: center;
+}
+
+.is-style-secondary-search-control > label {
+	flex: 0;
+	font-size: var(--wp--preset--font-size--extra-small) !important;
+	padding-right: var(--wp--preset--spacing--10) !important;
+}
+
+.is-style-secondary-search-control input[type="search"] {
+	border: none !important;
+	font-size: var(--wp--preset--font-size--extra-small) !important;
+	padding: 0 var(--wp--preset--spacing--10) !important;
+}
+
+.is-style-secondary-search-control .wp-block-search__inside-wrapper {
+	border: 1px solid var(--wp--preset--color--charcoal-1) !important;
+	border-radius: 2px !important;
+}
+
+.is-style-secondary-search-control button[type="submit"] {
+	background-color: transparent !important;
+	padding: calc(var(--wp--preset--spacing--10) / 2) !important;
+}
+
+.is-style-secondary-search-control button[type="submit"] svg {
+	fill: var(--wp--preset--color--charcoal-1) !important;
+}

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -67,6 +67,6 @@
 }
 
 .wp-block-search__button-inside.is-style-secondary-search-control
-	button[type="submit"] {
+button[type="submit"] {
 	margin: 2px;
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -28,6 +28,10 @@
 	padding: 0 var(--wp--preset--spacing--10) !important;
 }
 
+.wp-block-search__no-button.is-style-secondary-search-control input[type="search"] {
+	min-height: var(--wp--preset--spacing--30);
+}
+
 .is-style-secondary-search-control .wp-block-search__inside-wrapper {
 	border: 1px solid var(--wp--preset--color--charcoal-1) !important;
 	border-radius: 2px !important;
@@ -35,9 +39,21 @@
 
 .is-style-secondary-search-control button[type="submit"] {
 	background-color: transparent !important;
-	padding: calc(var(--wp--preset--spacing--10) / 2) !important;
+	color: var(--wp--preset--color--charcoal-1) !important;
 }
 
 .is-style-secondary-search-control button[type="submit"] svg {
 	fill: var(--wp--preset--color--charcoal-1) !important;
 }
+
+.wp-block-search__icon-button.is-style-secondary-search-control button[type="submit"] {
+	padding: calc(var(--wp--preset--spacing--10) / 2) !important;
+}
+
+.wp-block-search__text-button.is-style-secondary-search-control button[type="submit"] {
+	margin: 2px;
+	border: 1px solid var(--wp--preset--color--charcoal-1) !important;
+	font-size: var(--wp--preset--font-size--extra-small) !important;
+	padding: var(--wp--preset--spacing--10) !important;
+}
+

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -29,12 +29,22 @@
 }
 
 .wp-block-search__no-button.is-style-secondary-search-control input[type="search"] {
-	min-height: var(--wp--preset--spacing--30);
+	min-height: var(--wp--preset--spacing--40);
+	border: 1px solid var(--wp--preset--color--charcoal-1) !important;
 }
 
-.is-style-secondary-search-control .wp-block-search__inside-wrapper {
+.wp-block-search__button-inside.is-style-secondary-search-control .wp-block-search__inside-wrapper {
 	border: 1px solid var(--wp--preset--color--charcoal-1) !important;
 	border-radius: 2px !important;
+}
+
+.wp-block-search__button-outside.is-style-secondary-search-control input[type="search"] {
+	border: 1px solid var(--wp--preset--color--charcoal-1) !important;
+	border-radius: 2px !important;
+}
+
+.wp-block-search__button-outside.is-style-secondary-search-control button[type="submit"] {
+	border: 1px solid var(--wp--preset--color--charcoal-1) !important;
 }
 
 .is-style-secondary-search-control button[type="submit"] {
@@ -51,9 +61,12 @@
 }
 
 .wp-block-search__text-button.is-style-secondary-search-control button[type="submit"] {
-	margin: 2px;
 	border: 1px solid var(--wp--preset--color--charcoal-1) !important;
 	font-size: var(--wp--preset--font-size--extra-small) !important;
 	padding: var(--wp--preset--spacing--10) !important;
 }
 
+.wp-block-search__button-inside.is-style-secondary-search-control
+	button[type="submit"] {
+	margin: 2px;
+}

--- a/source/wp-content/themes/wporg-showcase-2022/templates/archive.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/archive.html
@@ -3,6 +3,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:query-title {"type":"archive"} /-->
+	<!-- wp:pattern {"slug":"wporg-showcase-2022/secondary-search-bar"} /-->
 
 	<!-- wp:query {"query":{"inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
 	<div class="wp-block-query">

--- a/source/wp-content/themes/wporg-showcase-2022/templates/front-page.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/front-page.html
@@ -2,7 +2,7 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">
-	<!-- wp:search {"label":"Search","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->
+	<!-- wp:pattern {"slug":"wporg-showcase-2022/secondary-search-bar"} /-->
 
 	<!-- wp:query {"queryId":16,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 	<div class="wp-block-query">

--- a/source/wp-content/themes/wporg-showcase-2022/templates/search.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/search.html
@@ -3,6 +3,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:query-title {"type":"search"} /-->
+	<!-- wp:pattern {"slug":"wporg-showcase-2022/secondary-search-bar"} /-->
 
 	<!-- wp:query {"query":{"inherit":true},"displayLayout":{"type":"flex","columns":3}} -->
 	<div class="wp-block-query">


### PR DESCRIPTION
This PR adds a pattern for the search bar which extends `core/search` with block styles. This PR also introduces a style component that imports a style sheet the same way we do in `wporg-main-2022`. See [this pull request](https://github.com/WordPress/wporg-main-2022/pull/125) for background info.

To be honest, this is the first time I have created block styles and I'm okay if there's a better `theme.json` way of doing it and I have to backtrack a bit. I had to use a lot of `!important` declarations to fight specificity. I'm wondering if that's the result of this being the wrong approach.

Additionally, I called this the secondary search bar because based on history, there is usually a large one that is included in the header. This search bar style seems to be only used in archive-like scenarios.


See: #9

## Variations

Note: Disregard the placeholder "Search Patterns". Updated the placeholder after the screenshots. 😆 

**Label, Button Inside, Icon** _This variation is currently in the designs._
<img width="437" alt="Screen Shot 2022-10-26 at 3 14 48 PM" src="https://user-images.githubusercontent.com/1657336/197948918-fd6c46ba-9290-46b4-bbd1-03a74d7da9d5.png">

**Label, Button Inside, Text** 
<img width="430" alt="Screen Shot 2022-10-26 at 3 14 36 PM" src="https://user-images.githubusercontent.com/1657336/197948922-0f33ed10-4d9f-4fda-91a1-679a1e0860c5.png">

**Label, Button Outside, Icon** 
<img width="428" alt="Screen Shot 2022-10-26 at 3 14 01 PM" src="https://user-images.githubusercontent.com/1657336/197948928-ce8e22d3-0753-400f-9025-b7d9e3cd95a1.png">

**Label, Button Outside, Text** 
<img width="422" alt="Screen Shot 2022-10-26 at 3 14 09 PM" src="https://user-images.githubusercontent.com/1657336/197948927-28bee2ef-442d-49de-8454-a8c762a7dd0f.png">
