### PR TITLE
Add a block style to control edge-spacing.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/inc/block-styles.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/block-styles.php
@@ -28,4 +28,13 @@ function setup_block_styles() {
 			'style_handle' => STYLE_HANDLE,
 		)
 	);
+
+	register_block_style(
+		'core/group',
+		array(
+			'name'         => 'edge-spacing',
+			'label'        => __( 'Edge Spacing', 'wporg' ),
+			'style_handle' => STYLE_HANDLE,
+		)
+	);
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -111,19 +111,7 @@ button[type="submit"] {
 	}
 }
 
-@media (max-width: 1199px) {
-
-	/* Once we start touching content, add in some side padding. */
-	.entry-content.entry-content > .alignwide,
-	.entry-content.entry-content > .alignfull {
-		padding-left: var(--wp--preset--spacing--60) !important;
-		padding-right: var(--wp--preset--spacing--60) !important;
-	}
-
-	/* Ensure nested full-alignment items are still full-width */
-	.entry-content.entry-content > .alignfull .alignfull {
-		margin-left: calc(var(--wp--preset--spacing--60) * -1) !important;
-		margin-right: calc(var(--wp--preset--spacing--60) * -1) !important;
-	}
-
+.wp-block-group.is-style-edge-spacing {
+	padding-left: var(--wp--custom--alignment--edge-spacing) !important;
+	padding-right: var(--wp--custom--alignment--edge-spacing) !important;
 }

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -2,8 +2,8 @@
 
 <!-- wp:wporg/site-screenshot /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80","top":"var:preset|spacing|50"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
-<main class="wp-block-group entry-content" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80","top":"var:preset|spacing|50"}}},"className":"entry-content is-style-edge-spacing","layout":{"type":"constrained"}} -->
+<main class="wp-block-group entry-content is-style-edge-spacing" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide"><!-- wp:post-title {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-2"} /-->
 
 <!-- wp:post-content /-->
@@ -12,12 +12,18 @@
 <p style="margin-top:var(--wp--preset--spacing--20)"><a href="[domain]">[pretty_domain]</a></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:pattern {"slug":"wporg-showcase-2022/related-posts"} /--></div>
+<!-- wp:group -->
+<div class="wp-block-group"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
+<h3 class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700">Related sites</h3>
+<!-- /wp:heading -->
+
+<!-- wp:jetpack/related-posts {"displayDate":false,"displayThumbnails":true} /--></div>
+<!-- /wp:group --></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->
 
-<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:post-navigation-link {"type":"previous","label":"Previous","showTitle":true,"linkLabel":true} /-->
+<!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20"}}},"className":"is-style-edge-spacing","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group is-style-edge-spacing" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-width:1px;border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20)"><!-- wp:post-navigation-link {"type":"previous","label":"Previous","showTitle":true,"linkLabel":true} /-->
 
 <!-- wp:post-navigation-link {"label":"Next","showTitle":true,"linkLabel":true} /--></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/theme.json
+++ b/source/wp-content/themes/wporg-showcase-2022/theme.json
@@ -1,7 +1,15 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
-	"settings": {},
+	"settings": {
+		"custom": {
+			"alignment": {
+				"alignedMaxWidth": "50%",
+				"//edge-spacing": "The min and max values represent the mobile and desktop spacing; the calc() value is for tablets.",
+				"edge-spacing": "clamp( 24px, calc( 100vw / 18 ), 80px )"
+			}
+		}
+	},
 	"styles": {
 		"blocks": {
 			"core/quote": {

--- a/source/wp-content/themes/wporg-showcase-2022/theme.json
+++ b/source/wp-content/themes/wporg-showcase-2022/theme.json
@@ -4,7 +4,6 @@
 	"settings": {
 		"custom": {
 			"alignment": {
-				"alignedMaxWidth": "50%",
 				"//edge-spacing": "The min and max values represent the mobile and desktop spacing; the calc() value is for tablets.",
 				"edge-spacing": "clamp( 24px, calc( 100vw / 18 ), 80px )"
 			}


### PR DESCRIPTION
I'm having a difficult time creating consistency between the edges of the browser and containers. This PR adds a block style for groups that will allow us to apply the `edge-spacing` CSS to ensure consistency across components and pages. I _think_ this makes sense.

The calculation used for the edge spacing was taken from `wporg-news-2021`:
```
clamp( 24px, calc( 100vw / 18 ), 80px )
```


# Screenshot

| Mobile | Desktop |
| --- | --- |
| <img width="300" alt="Screen Shot 2022-11-03 at 11 53 07 AM" src="https://user-images.githubusercontent.com/1657336/199639243-5de3323f-037b-4c39-8696-4473df64754d.png"> |  <img width="1419" alt="Screen Shot 2022-11-03 at 12 02 41 PM" src="https://user-images.githubusercontent.com/1657336/199640083-d12ad890-674b-48b3-9284-0d39de33d434.png"> |


