### PR TITLE
Screenshot Block: Improve editor support with context, block supports

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
@@ -11,8 +11,14 @@
 	"attributes": {},
 	"supports": {
 		"align": true,
-		"html": false
+		"html": false,
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"padding": true,
+			"blockGap": false
+		}
 	},
+	"usesContext": [ "postId" ],
 	"editorScript": "file:./index.js",
 	"style": "file:./style-index.css"
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -1,9 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { image } from '@wordpress/icons';
 import { Placeholder } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
-import { image } from '@wordpress/icons';
+import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -12,7 +13,11 @@ import metadata from './block.json';
 import './style.scss';
 
 function Edit() {
-	return <Placeholder icon={ image } label="Site Screenshot" />;
+	return (
+		<div { ...useBlockProps() }>
+			<Placeholder icon={ image } label="Site Screenshot" />
+		</div>
+	);
 }
 
 registerBlockType( metadata.name, {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -31,10 +31,19 @@ function init() {
 /**
  * Render the block content.
  *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
  * @return string Returns the block markup.
  */
-function render() {
-	global $post;
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_ID = $block->context['postId'];
+	$post = get_post( $post_ID );
 	$width = 1320;
 	$height = 670;
 
@@ -44,5 +53,12 @@ function render() {
 	$srcset = add_query_arg( 'vpw', $width * 2, $screenshot );
 	$srcset = add_query_arg( 'vph', $height * 2, $srcset );
 
-	return "<img src='{$screenshot}' srcset='$srcset 2x' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' class='wp-block-wporg-site-screenshot' />";
+	$img_content = "<img src='{$screenshot}' srcset='$srcset 2x' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' />";
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	return sprintf(
+		'<div %s>%s</div>',
+		$wrapper_attributes,
+		$img_content
+	);
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
@@ -1,3 +1,6 @@
 .wp-block-wporg-site-screenshot {
-	width: 100%;
+	img {
+		max-width: 100%;
+		vertical-align: middle;
+	}
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
@@ -1,6 +1,6 @@
 .wp-block-wporg-site-screenshot {
 	img {
-		max-width: 100%;
+		width: 100%;
 		vertical-align: middle;
 	}
 }

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -1,9 +1,9 @@
 <!-- wp:template-part {"slug":"header","theme":"wporg-showcase-2022"} /-->
 
-<!-- wp:wporg/site-screenshot /-->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
+<main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:wporg/site-screenshot {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80","top":"var:preset|spacing|50"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
-<main class="wp-block-group entry-content" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide"><!-- wp:post-title {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-2"} /-->
 
 <!-- wp:post-content /-->


### PR DESCRIPTION
This updates the Screenshot block to use the current post context (which will be more relevant if this is used anywhere the global post is different than expected, like maybe if you use it in a query loop on a different page). I've also added a wrapper which adds `get_block_wrapper_attributes` — this provides [the core block supports](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/) (like the generated className, and any `supports` properties). This was needed, because I also added spacing block supports, so now that's generated and applied to the block wrapper.

Lastly, I updated the single template to move the screenshot inside of the `main` wrapper, and applied a bottom margin to it to match the previous top padding space.

**Screenshots**

| Before | After |
|-------|-------|
| ![showcase-ss-before](https://user-images.githubusercontent.com/541093/200065509-90ec9a4d-5955-4d3c-a42a-327934091eb2.png) | ![showcase-ss-after](https://user-images.githubusercontent.com/541093/200065506-0c1454bf-d27d-42e1-a380-26fa55b7e1e8.png) |

Code before:

```
<img decoding="async" src="https://wordpress.com/mshots/v1/http%3A%2F%2Fwww.tonal.com%2F%3Fv%3D1.0?vpw=1320&amp;vph=670" srcset="https://wordpress.com/mshots/v1/http%3A%2F%2Fwww.tonal.com%2F%3Fv%3D1.0?vpw=2640&amp;vph=1340 2x" alt="Tonal" class="wp-block-wporg-site-screenshot">
```

Code after:

```
<div style="margin-bottom:var(--wp--preset--spacing--50);" class="alignfull wp-block-wporg-site-screenshot">
    <img decoding="async" src="https://wordpress.com/mshots/v1/http%3A%2F%2Fwww.tonal.com%2F%3Fv%3D1.0?vpw=1320&amp;vph=670" srcset="https://wordpress.com/mshots/v1/http%3A%2F%2Fwww.tonal.com%2F%3Fv%3D1.0?vpw=2640&amp;vph=1340 2x" alt="Tonal">
</div>
```

