### PR TITLE
Try adding inline space to all blocks when on smaller screens

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -111,19 +111,12 @@ button[type="submit"] {
 	}
 }
 
-@media (max-width: 1199px) {
-
-	/* Once we start touching content, add in some side padding. */
-	.entry-content.entry-content > .alignwide,
-	.entry-content.entry-content > .alignfull {
-		padding-left: var(--wp--preset--spacing--60) !important;
-		padding-right: var(--wp--preset--spacing--60) !important;
+// 760 = (--wp--style--global--content-size, 680px) + (2 * --wp--preset--spacing--60, which at ~700 is 40px).
+@media (max-width: 760px) {
+	// Add space to the left & right of blocks as long as they're not pulled out
+	// of the content by left, right, wide, or full alignment.
+	body .is-layout-constrained > *:not(.alignleft):not(.alignright):not(.alignfull):not(.alignwide) {
+		margin-left: var(--wp--preset--spacing--60) !important;
+		margin-right: var(--wp--preset--spacing--60) !important;
 	}
-
-	/* Ensure nested full-alignment items are still full-width */
-	.entry-content.entry-content > .alignfull .alignfull {
-		margin-left: calc(var(--wp--preset--spacing--60) * -1) !important;
-		margin-right: calc(var(--wp--preset--spacing--60) * -1) !important;
-	}
-
 }

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page-submit.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page-submit.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:post-title /-->
-	<!-- wp:post-content /-->
+	<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
 </main>
 <!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header"} /-->
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content"} -->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">
 	<!-- wp:post-content /-->
 </main>

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -3,17 +3,15 @@
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:wporg/site-screenshot {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
 
-<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide"><!-- wp:post-title {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-2"} /-->
+<!-- wp:post-title {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-2"} /-->
 
-<!-- wp:post-content /-->
+<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
 
 <!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}}} -->
 <p style="margin-top:var(--wp--preset--spacing--20)"><a href="[domain]">[pretty_domain]</a></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:pattern {"slug":"wporg-showcase-2022/related-posts"} /--></div>
-<!-- /wp:group --></main>
+<!-- wp:pattern {"slug":"wporg-showcase-2022/related-posts"} /--></main>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px"},"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->


### PR DESCRIPTION
Alternative approach to #30 — Since this behavior (space around the blocks) should probably be universal across pages, I've updated the media query to add a margin to blocks when the page size is about to run into the sides. I think this might be a better approach to the issue, rather than needing to apply the block style on each page.

I also updated the single template slightly to remove an unnecessary group, and the page template to add the layout properties to `wp:post-content` — using this method also adds support for wide & full alignment in post content.

For example, I added a wide-width box to the showcase site template. It stays wide until it hits the edges, then it stays edge-to-edge all the way to mobile screens.

(I only took 2 page screenshots, there was less obvious difference there)

| Size | Showcase site | Page |
|------|---------------|------|
| 1400 | <img src="https://user-images.githubusercontent.com/541093/200074322-4e641841-f770-491b-a515-8e45e92314ea.png" width="300" /> | - |
| 800 | <img src="https://user-images.githubusercontent.com/541093/200074314-1f00761d-f4ef-475f-aeab-2b75b27ae9bd.png" width="300" /> | <img src="https://user-images.githubusercontent.com/541093/200074304-bee14dd3-f730-40ff-b1d9-03f4602c5573.png" width="300" /> |
| 600 | <img src="https://user-images.githubusercontent.com/541093/200074311-35d54d4b-4dac-40fc-a4f4-50a2ebc2db49.png" width="300" /> | - |
| 400 | <img src="https://user-images.githubusercontent.com/541093/200074305-400ea45e-da13-404a-95be-00db9873c65c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/541093/200074302-be25d09b-f4b8-434d-b3eb-fedfdb3523c7.png" width="300" /> |