### PR TITLE
Add JetPack contact form for site submission.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -18,6 +18,9 @@ add_filter( 'excerpt_length', __NAMESPACE__ . '\modify_excerpt_length', 999 );
 add_filter( 'excerpt_more', __NAMESPACE__ . '\modify_excerpt_more' );
 add_filter( 'query_loop_block_query_vars', __NAMESPACE__ . '\modify_query_loop_block_query_vars', 10, 2 );
 
+// Don't send an email on contact for submission
+add_filter( 'grunion_should_send_email', '__return_false' );
+
 /**
  * Enqueue scripts and styles.
  */

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit.php
@@ -46,8 +46,8 @@ _e( 'While only a relatively small number of submissions are eventually added to
 <h2 class="has-heading-3-font-size" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'Submission Form', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:list {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"var:preset|spacing|20"}}}} -->
-<ul style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:list-item -->
+<!-- wp:list {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|20,"left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"var:preset|spacing|20"}}}} -->
+<ul style="margin-top:0;margin-right:0;margin-bottom:var(--wp--preset--spacing--20);margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:list-item -->
 <li><?php esc_attr_e( 'All the fields are required.', 'wporg' ); ?></li>
 <!-- /wp:list-item -->
 
@@ -55,3 +55,27 @@ _e( 'While only a relatively small number of submissions are eventually added to
 <li><?php esc_attr_e( 'Please insert the site information &amp; descriptions in English, regardless of the sites language.', 'wporg' ); ?></li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list -->
+
+<!-- wp:jetpack/contact-form {"subject":"<?php esc_attr_e( 'A new showcase site suggested.', 'wporg' ); ?>","to":"showcase.shouldbeblockedbyfilter@wordpress.org","customThankyou":"redirect","customThankyouRedirect":"https://wordpress.org/showcase/submit-a-wordpress-site/success"} -->
+<div class="wp-block-jetpack-contact-form"><!-- wp:jetpack/field-name {"label":"<?php esc_attr_e( 'Your Name', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-email {"label":"<?php esc_attr_e( 'Your E-mail', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-url {"label":"<?php esc_attr_e( 'Site URL', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Country', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Theme', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-date {"label":"<?php esc_attr_e( 'Launched On', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-text {"label":"<?php esc_attr_e( 'Author', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'Describe the site and, if applicable, the person or organization it represents.', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-textarea {"label":"<?php esc_attr_e( 'What justifies this site being added to the WordPress Showcase? what makes it unique or interesting?', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/field-checkbox {"label":"<?php esc_attr_e( 'Check this box if you own the site and agree to be contacted by email', 'wporg' ); ?>","required":true} /-->
+
+<!-- wp:jetpack/button {"element":"button","text":"<?php esc_attr_e( 'Submit site', 'wporg' ); ?>","lock":{"remove":true}} /--></div>
+<!-- /wp:jetpack/contact-form -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Submit a WordPres Site
+ * Title: Submit a WordPress Site
  * Slug: wporg-showcase-2022/page-submit
  * Inserter: no
  */

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit.php
@@ -46,7 +46,7 @@ _e( 'While only a relatively small number of submissions are eventually added to
 <h2 class="has-heading-3-font-size" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'Submission Form', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:list {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|20,"left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"var:preset|spacing|20"}}}} -->
+<!-- wp:list {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|20","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"var:preset|spacing|20"}}}} -->
 <ul style="margin-top:0;margin-right:0;margin-bottom:var(--wp--preset--spacing--20);margin-left:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:list-item -->
 <li><?php esc_attr_e( 'All the fields are required.', 'wporg' ); ?></li>
 <!-- /wp:list-item -->

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -135,15 +135,16 @@ button[type="submit"] {
  */
 
 .wp-block-jetpack-contact-form label {
-	font-weight: 400;
+	font-weight: 400 !important;
 }
 
 .wp-block-jetpack-contact-form input[type="email"],
 .wp-block-jetpack-contact-form input[type="tel"],
 .wp-block-jetpack-contact-form input[type="text"],
-.wp-block-jetpack-contact-form input[type="url"] {
-	padding: 4px 8px;
-	border: 1px solid var(--wp--preset--color--charcoal-4);
+.wp-block-jetpack-contact-form input[type="url"],
+.wp-block-jetpack-contact-form textarea  {
+	padding: 4px 8px !important;
+	border: 1px solid var(--wp--preset--color--charcoal-4) !important;
 }
 
 // 760 = (--wp--style--global--content-size, 680px) + (2 * --wp--preset--spacing--60, which at ~700 is 40px).

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -134,14 +134,14 @@ button[type="submit"] {
  * JetPack Contact Form Styles
  */
 
- .wp-block-jetpack-contact-form label {
-	font-weight: normal;
+.wp-block-jetpack-contact-form label {
+	font-weight: 400;
 }
 
-.wp-block-jetpack-contact-form input[type=email],
-.wp-block-jetpack-contact-form input[type=tel],
-.wp-block-jetpack-contact-form input[type=text],
-.wp-block-jetpack-contact-form input[type=url] {
+.wp-block-jetpack-contact-form input[type="email"],
+.wp-block-jetpack-contact-form input[type="tel"],
+.wp-block-jetpack-contact-form input[type="text"],
+.wp-block-jetpack-contact-form input[type="url"] {
 	padding: 4px 8px;
 	border: 1px solid var(--wp--preset--color--charcoal-4);
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -142,7 +142,7 @@ button[type="submit"] {
 .wp-block-jetpack-contact-form input[type="tel"],
 .wp-block-jetpack-contact-form input[type="text"],
 .wp-block-jetpack-contact-form input[type="url"],
-.wp-block-jetpack-contact-form textarea  {
+.wp-block-jetpack-contact-form textarea {
 	padding: 4px 8px !important;
 	border: 1px solid var(--wp--preset--color--charcoal-4) !important;
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -130,6 +130,22 @@ button[type="submit"] {
 	}
 }
 
+/*
+ * JetPack Contact Form Styles
+ */
+
+ .wp-block-jetpack-contact-form label {
+	font-weight: normal;
+}
+
+.wp-block-jetpack-contact-form input[type=email],
+.wp-block-jetpack-contact-form input[type=tel],
+.wp-block-jetpack-contact-form input[type=text],
+.wp-block-jetpack-contact-form input[type=url] {
+	padding: 4px 8px;
+	border: 1px solid var(--wp--preset--color--charcoal-4);
+}
+
 // 760 = (--wp--style--global--content-size, 680px) + (2 * --wp--preset--spacing--60, which at ~700 is 40px).
 @media (max-width: 760px) {
 	// Add space to the left & right of blocks as long as they're not pulled out


### PR DESCRIPTION
Status: Awaiting better descriptions for the form fields.

<hr>

Fixes #7, #8

This PR introduces the `page-submit.php` pattern with a feedback form built with the JetPack form builder to receive new showcase site submissions.

# How It currently works on `/showcase`
We currently use comments to receive new site submissions. The front end uses some custom javascript to hide the comment form and display a different form that sources the data. It combines all that data and submits it as a comment. We can't do that without creating a custom component and building a custom form builder which would greatly add to the scope of this, probably unnecessarily.

# How it could work moving forward
Let's use the JetPack form builder, which is already installed on .org, and rely on their feedback flow to received sites. This will give us a form builder and a tested feedback management system right out of the box.

# How does it work
## Building
Here's the form built with JetPack CF:
<img width="367" alt="Screen Shot 2022-11-17 at 9 16 37 AM" src="https://user-images.githubusercontent.com/1657336/202332984-2e671ba9-d9dd-40b6-a7e2-ea351fdf948c.png">

## Managing

### Click "Feedback" in Admin sidebar
<img width="160" alt="Screen Shot 2022-11-17 at 11 30 39 AM" src="https://user-images.githubusercontent.com/1657336/202340143-d39dad31-1321-44c1-8e07-e1cabfade4eb.png">

### Form Results

<img width="500" alt="Screen Shot 2022-11-17 at 11 30 51 AM" src="https://user-images.githubusercontent.com/1657336/202341291-fa64c072-2ec8-4ede-a351-5c6fe82d086d.png">

## How to Test
You'll need to test on your sandbox.

1. Copy over `templates/page-submit.html` and `patterns/page-submit.php` to sandbox
2. Visits `/showcase-test/submit-a-wordpress-site`
3. Log into admin, view feedback as described above.
