### PR TITLE
Add the ability to make the screenshot block clickable in templates.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/archive-content.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/archive-content.php
@@ -15,7 +15,7 @@
 	<div class="wp-block-query"><!-- wp:post-template -->
 	
 	<!-- wp:group {"style":{"border":{"width":"1px"}},"borderColor":"light-grey-1"} -->
-	<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px"><!-- wp:wporg/site-screenshot /--></div>
+	<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px"><!-- wp:wporg/site-screenshot {"isLink":true} /--></div>
 	<!-- /wp:group -->
 	
 	<!-- wp:post-title {"isLink":true,"fontSize":"normal","fontFamily":"inter"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -37,7 +37,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:wporg/site-screenshot {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} /--></div>
+<!-- wp:wporg/site-screenshot {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}},"isLink":true} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 <!-- /wp:post-template --></div>
@@ -59,7 +59,7 @@
 <!-- wp:query {"queryId":16,"query":{"perPage":20,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[8]}},"displayLayout":{"type":"flex","columns":2}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:group {"style":{"border":{"width":"1px"}},"borderColor":"light-grey-1","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px"><!-- wp:wporg/site-screenshot {"align":"full"} /--></div>
+<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px"><!-- wp:wporg/site-screenshot {"align":"full","isLink":true} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:post-title {"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
@@ -8,7 +8,12 @@
 	"icon": "",
 	"description": "Display a screenshot of the site.",
 	"textdomain": "wporg",
-	"attributes": {},
+	"attributes": {
+		"isLink": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"supports": {
 		"align": true,
 		"html": false,

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -2,9 +2,10 @@
  * WordPress dependencies
  */
 import { image } from '@wordpress/icons';
-import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { PanelBody, Placeholder, ToggleControl } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
-import { useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -12,9 +13,18 @@ import { useBlockProps } from '@wordpress/block-editor';
 import metadata from './block.json';
 import './style.scss';
 
-function Edit() {
+function Edit( { attributes: { isLink }, setAttributes } ) {
 	return (
 		<div { ...useBlockProps() }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'wporg' ) }>
+					<ToggleControl
+						label={ __( 'Make image link to Post', 'wporg' ) }
+						checked={ isLink }
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<Placeholder icon={ image } label="Site Screenshot" />
 		</div>
 	);

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -25,7 +25,7 @@ function Edit( { attributes: { isLink }, setAttributes } ) {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Placeholder icon={ image } label="Site Screenshot" />
+			<Placeholder icon={ image } label={ __( 'Site Screenshot', 'wporg' ) } />
 		</div>
 	);
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -53,7 +53,7 @@ function render( $attributes, $content, $block ) {
 
 	$img_content = "<img src='{$screenshot}' srcset='$srcset 2x' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' />";
 
-	if ( isset( $attributes['isLink'] ) ) {
+	if ( isset( $attributes['isLink'] ) && true == $attributes['isLink'] ) {
 		$img_content .= '<span class="screen-reader-text">' . the_title_attribute( array( 'echo' => false ) ) . '</span>';
 		$img_content = '<a href="' . get_permalink( $post ) . '">' . $img_content . '</a>';
 	}

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -54,7 +54,6 @@ function render( $attributes, $content, $block ) {
 	$img_content = "<img src='{$screenshot}' srcset='$srcset 2x' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' />";
 
 	if ( isset( $attributes['isLink'] ) && true == $attributes['isLink'] ) {
-		$img_content .= '<span class="screen-reader-text">' . the_title_attribute( array( 'echo' => false ) ) . '</span>';
 		$img_content = '<a href="' . get_permalink( $post ) . '">' . $img_content . '</a>';
 	}
 

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -53,6 +53,11 @@ function render( $attributes, $content, $block ) {
 
 	$img_content = "<img src='{$screenshot}' srcset='$srcset 2x' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' />";
 
+	if ( isset( $attributes['isLink'] ) ) {
+		$img_content .= '<span class="screen-reader-text">' . the_title_attribute( array( 'echo' => false ) ) . '</span>';
+		$img_content = '<a href="' . get_permalink( $post ) . '">' . $img_content . '</a>';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes();
 	return sprintf(
 		'<div %s>%s</div>',


### PR DESCRIPTION
Fixes #46 

This PR adds the ability to make the screenshot block clickable. This pr allows developers the ability to add `"isLink":true` to the block in the template which will wrap the image in a link and use the permalink of the associated post as the href.

This PR doesn't introduce controls in the block editor to toggle it. I'm not sure it's necessary at this point.

# Generated HTML

```
<div class="wp-block-wporg-site-screenshot">
    <a href="http://localhost:8888/post-name/">
      <img {....}>
      <span class="screen-reader-text">Post Name</span>
   </a>
</div>
```

