### PR TITLE
Apply style updates from Subpage Header Bar pattern

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/parts/header.html
+++ b/source/wp-content/themes/wporg-showcase-2022/parts/header.html
@@ -1,4 +1,3 @@
-<!-- wp:group {"style":{"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-width:1px"><!-- wp:wporg/global-header {"style":"black-on-white"} /--></div>
-<!-- /wp:group -->
+<!-- wp:wporg/global-header {"style":"black-on-white"} /-->
+
 <!-- wp:pattern {"slug":"wporg-showcase-2022/subnav-bar"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/subnav-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/subnav-bar.php
@@ -7,12 +7,12 @@
 
 ?>
 
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|20","bottom":"0","left":"var:preset|spacing|20"},"margin":{"bottom":"16px"}}},"backgroundColor":"white","textColor":"white","className":"is-style-brush-stroke","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke has-white-color has-white-background-color has-text-color has-background has-link-color" style="margin-bottom:16px;padding-top:16px;padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"charcoal-1","fontSize":"normal"} -->
-<p class="has-charcoal-1-color has-text-color has-normal-font-size" style="font-style:normal;font-weight:700">Showcase</p>
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|20","bottom":"0","left":"var:preset|spacing|20"},"margin":{"bottom":"16px"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px","style":"solid"}}},"backgroundColor":"white","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-brush-stroke has-white-color has-white-background-color has-text-color has-background has-link-color is-sticky" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;margin-bottom:16px;padding-top:16px;padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"charcoal-1","fontSize":"small"} -->
+<p class="has-charcoal-1-color has-text-color has-small-font-size" style="font-weight:700">Showcase</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:navigation {"ref":7299,"textColor":"blueberry-1","backgroundColor":"white","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"var:preset|spacing|30"}}} /--></div>
+<!-- wp:navigation {"ref":7299,"textColor":"blueberry-1","backgroundColor":"white","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/subnav-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/subnav-bar.php
@@ -7,9 +7,9 @@
 
 ?>
 
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|20","bottom":"0","left":"var:preset|spacing|20"},"margin":{"bottom":"16px"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px","style":"solid"}}},"backgroundColor":"white","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke has-white-color has-white-background-color has-text-color has-background has-link-color is-sticky" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;margin-bottom:16px;padding-top:16px;padding-right:var(--wp--preset--spacing--20);padding-bottom:0;padding-left:var(--wp--preset--spacing--20)"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"charcoal-1","fontSize":"small"} -->
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"},"margin":{"bottom":"16px"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px","style":"solid"}}},"backgroundColor":"white","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull is-style-brush-stroke has-white-color has-white-background-color has-text-color has-background has-link-color is-sticky" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;margin-bottom:16px;padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull"><!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"textColor":"charcoal-1","fontSize":"small"} -->
 <p class="has-charcoal-1-color has-text-color has-small-font-size" style="font-weight:700">Showcase</p>
 <!-- /wp:paragraph -->
 

--- a/source/wp-content/themes/wporg-showcase-2022/templates/archive.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/archive.html
@@ -1,3 +1,5 @@
-<!-- wp:template-part {"slug":"header","theme":"wporg-showcase-2022"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+
 <!-- wp:pattern {"slug":"wporg-showcase-2022/archive-content"} /-->
+
 <!-- wp:wporg/global-footer {"style":"black-on-white"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/templates/category.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/category.html
@@ -1,3 +1,0 @@
-<!-- wp:template-part {"slug":"header","theme":"wporg-showcase-2022"} /-->
-<!-- wp:pattern {"slug":"wporg-showcase-2022/archive-content"} /-->
-<!-- wp:wporg/global-footer {"style":"black-on-white"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/templates/index.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/index.html
@@ -1,3 +1,5 @@
-<!-- wp:template-part {"slug":"header","theme":"wporg-showcase-2022"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+
 <!-- wp:pattern {"slug":"wporg-showcase-2022/archive-content"} /-->
+
 <!-- wp:wporg/global-footer {"style":"black-on-white"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page-submit.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page-submit.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">

--- a/source/wp-content/themes/wporg-showcase-2022/templates/search.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/search.html
@@ -1,3 +1,5 @@
-<!-- wp:template-part {"slug":"header","theme":"wporg-showcase-2022"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
+
 <!-- wp:pattern {"slug":"wporg-showcase-2022/archive-content"} /-->
+
 <!-- wp:wporg/global-footer {"style":"black-on-white"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","theme":"wporg-showcase-2022"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:wporg/site-screenshot {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->


### PR DESCRIPTION
This applies the subnav style changes from the Parent theme, https://github.com/WordPress/wporg-parent-2021/commit/40f4a3dba3e477502ca7fbe5a82f986828eb239d (see https://github.com/WordPress/wporg-parent-2021/issues/55, https://github.com/WordPress/wporg-parent-2021/issues/56). The font should be `small`, the gap between items has been updated, and the current page is highlighted using a bold style.

Additionally, I've deleted the `category.html` template in the parent theme, since we've had to work around it in each child theme by duplicating the archive template. That means we can also delete that file here, and the category archive uses the child theme's `archive.html` template.

Finally, I've updated how the sticky subnav header works — I'm _assuming_ this is meant to be sticky here, since that's the behavior on the main site. There are two changes from the parent theme for this:
- Add an `is-sticky` class which is used on the Brush Stroke styled Group block, and that allows the block to be sticky.
- Add a `has-display-contents` helper class which is used on the template part block to render the template block wrapper inert style-wise — without this, the `position: sticky` on the subnav doesn't work.

### Screenshots

| Page | Screenshot |
|----|-----|
| Home (no change) | ![home](https://user-images.githubusercontent.com/541093/202556159-9164ce74-f073-40af-b2c4-f2342f13ccc9.png) |
| Single site, scrolled down, subnav is also sticky now | ![single](https://user-images.githubusercontent.com/541093/202555827-81f15b3d-e331-4e13-9113-a17859f0c609.png) |
| A category archive, inherits the child's `archive.html` properly | ![archive](https://user-images.githubusercontent.com/541093/202555819-6c5c2feb-74a3-4314-9518-a688ed7b99ce.png) |
| Single page, page in nav is bold | ![page](https://user-images.githubusercontent.com/541093/202555823-ea48f21b-92fe-48df-856a-a0605d3cd045.png) |
