### PR TITLE
Update the page-submit callout on the front page.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page-submit.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page-submit.php
@@ -8,7 +8,7 @@
 ?>
 
 <!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-bottom:80px"><!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"60px","padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"1160px"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-bottom:80px"><!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"60px","padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"justifyContent":"left"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
 <h2 class="is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/showcase/submit-a-wordpress-site/"><?php esc_attr_e( 'Submit a site', 'wporg' ); ?></a></h2>
 <!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page-submit.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page-submit.php
@@ -7,17 +7,29 @@
 
 ?>
 
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-bottom:80px"><!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"60px","padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"1160px"}} -->
-<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"80px","bottom":"80px","right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-right:var(--wp--preset--spacing--60);padding-bottom:80px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"1160px"} -->
+<div class="wp-block-column" style="flex-basis:1160px"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
 <h2 class="is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/showcase/submit-a-wordpress-site/"><?php esc_attr_e( 'Submit a site', 'wporg' ); ?></a></h2>
-<!-- /wp:heading -->
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
 
 <!-- wp:columns {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-columns"><!-- wp:column {"width":"570px"} -->
 <div class="wp-block-column" style="flex-basis:570px"><!-- wp:paragraph {"className":"is-style-short-text","fontSize":"large"} -->
 <p class="is-style-short-text has-large-font-size"><?php esc_attr_e( 'Submit your site to the WordPress Showcase and have it featured next to some of the most beautiful and best designed WordPress websites in the world.', 'wporg' ); ?></p>
 <!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
 <!-- /wp:group --></div>

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page-submit.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page-submit.php
@@ -8,7 +8,7 @@
 ?>
 
 <!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-bottom:80px"><!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"60px","padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"justifyContent":"left"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-bottom:80px"><!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"60px","padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"1160px"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
 <h2 class="is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/showcase/submit-a-wordpress-site/"><?php esc_attr_e( 'Submit a site', 'wporg' ); ?></a></h2>
 <!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page-submit.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page-submit.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Title: Front Page Submit Callout
+ * Slug: wporg-showcase-2022/front-page-submit
+ * Inserter: no
+ */
+
+?>
+
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-bottom:80px"><!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"60px","padding":{"right":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"constrained","justifyContent":"left","contentSize":"1160px"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
+<h2 class="is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/showcase/submit-a-wordpress-site/"><?php esc_attr_e( 'Submit a site', 'wporg' ); ?></a></h2>
+<!-- /wp:heading -->
+
+<!-- wp:columns {"style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-columns"><!-- wp:column {"width":"570px"} -->
+<div class="wp-block-column" style="flex-basis:570px"><!-- wp:paragraph {"className":"is-style-short-text","fontSize":"large"} -->
+<p class="is-style-short-text has-large-font-size"><?php esc_attr_e( 'Submit your site to the WordPress Showcase and have it featured next to some of the most beautiful and best designed WordPress websites in the world.', 'wporg' ); ?></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -77,6 +77,7 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
+<<<<<<< HEAD
 <!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-bottom:80px;"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"60px"}}} -->
 <div class="wp-block-group alignwide"><!-- wp:heading {"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
@@ -97,3 +98,5 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
+=======
+>>>>>>> d03c024 (Update the page-submit callout on the front page.)

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -77,26 +77,3 @@
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 
-<<<<<<< HEAD
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"80px","bottom":"80px"}}},"backgroundColor":"charcoal-2","textColor":"white","layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-white-color has-charcoal-2-background-color has-text-color has-background has-link-color" id="get-started" style="padding-top:80px;padding-bottom:80px;"><!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"60px"}}} -->
-<div class="wp-block-group alignwide"><!-- wp:heading {"align":"wide","style":{"typography":{"fontStyle":"normal","fontWeight":"300","letterSpacing":"-2px"}},"className":"is-style-with-arrow","fontSize":"heading-cta","fontFamily":"inter"} -->
-<h2 class="alignwide is-style-with-arrow has-inter-font-family has-heading-cta-font-size" style="font-style:normal;font-weight:300;letter-spacing:-2px"><a href="https://wordpress.org/showcase/submit-a-wordpress-site/"><?php esc_attr_e( 'Submit a site', 'wporg' ); ?></a></h2>
-<!-- /wp:heading -->
-
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"0px"}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"40%"} -->
-<div class="wp-block-column" style="flex-basis:40%"><!-- wp:paragraph {"className":"is-style-short-text"} -->
-<p class="is-style-short-text"><?php esc_attr_e( 'Submit your site to the WordPress Showcase and have it featured next to some of the most beautiful and best designed WordPress websites in the world.', 'wporg' ); ?></p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
-=======
->>>>>>> d03c024 (Update the page-submit callout on the front page.)

--- a/source/wp-content/themes/wporg-showcase-2022/templates/front-page.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/front-page.html
@@ -6,4 +6,6 @@
 </main>
 <!-- /wp:group -->
 
+<!-- wp:pattern {"slug":"wporg-showcase-2022/front-page-submit"} /-->
+
 <!-- wp:wporg/global-footer {"style":"white-on-black"} /-->


### PR DESCRIPTION
This PR aligns the submit callout to the left side.

Notes: changes agreed upon here need to be ported to the same component on the homepage.
[Parent pattern link](https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/patterns/heading-with-arrow.php).


## ScreenShots
<img width="1784" alt="Screen Shot 2022-11-24 at 2 15 04 PM" src="https://user-images.githubusercontent.com/1657336/203700390-df4c0ee1-9de9-4e16-9fc0-91ea89c86f19.png">



