### PR TITLE
Design Audit: Reduce subnav text size

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/subnav-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/subnav-bar.php
@@ -9,7 +9,7 @@
 
 <!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"},"margin":{"bottom":"16px"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px","style":"solid"}}},"backgroundColor":"white","textColor":"white","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull is-style-brush-stroke has-white-color has-white-background-color has-text-color has-background has-link-color is-sticky" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;margin-bottom:16px;padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull"><!-- wp:wporg/site-breadcrumbs {"textColor":"charcoal-1"} /-->
+<div class="wp-block-group alignfull"><!-- wp:wporg/site-breadcrumbs {"textColor":"charcoal-1","fontSize":"small"} /-->
 
 
 <!-- wp:navigation {"ref":7299,"textColor":"blueberry-1","backgroundColor":"white","className":"is-style-dropdown-on-mobile","style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /--></div>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-breadcrumbs/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-breadcrumbs/style.scss
@@ -1,7 +1,6 @@
 .wp-block-wporg-site-breadcrumbs > div {
 	display: flex;
 	align-items: center;
-	min-height: var(--local-header-height);
 
 	a {
 		color: inherit;
@@ -14,7 +13,6 @@
 
 	> div {
 		font-family: var(--wp--preset--font-family--inter);
-		font-size: 1rem;
 		font-weight: 700;
 		line-height: inherit;
 


### PR DESCRIPTION
See https://github.com/WordPress/wporg-showcase-2022/issues/59

## Screenshots


<img width="1851" alt="image" src="https://user-images.githubusercontent.com/18050944/204377681-abcef010-56da-490e-b4ae-518c9e8eb1b3.png">


<img width="1875" alt="image" src="https://user-images.githubusercontent.com/18050944/204377462-5a56d9ae-aed9-42c2-87fb-ab7a11272602.png">
