### PR TITLE
Design Audit: Remove paintbrush stroke

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/subnav-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/subnav-bar.php
@@ -7,8 +7,8 @@
 
 ?>
 
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"0","left":"var:preset|spacing|60"},"margin":{"bottom":"16px"}},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px","style":"solid"}}},"backgroundColor":"white","textColor":"charcoal-1","className":"is-style-brush-stroke is-sticky","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull is-style-brush-stroke has-charcoal-1-color has-white-background-color has-text-color has-background has-link-color is-sticky" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;margin-bottom:16px;padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:0;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|charcoal-1"}}},"spacing":{"padding":{"top":"16px","right":"var:preset|spacing|60","bottom":"16px","left":"var:preset|spacing|60"},"border":{"top":{"color":"var:preset|color|light-grey-1","width":"1px","style":"solid"}}},"backgroundColor":"white","textColor":"charcoal-1","className":"is-sticky","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-charcoal-1-color has-white-background-color has-text-color has-background has-link-color is-sticky" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;border-top-width:1px;padding-top:16px;padding-right:var(--wp--preset--spacing--60);padding-bottom:16px;padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignfull"><!-- wp:wporg/site-breadcrumbs {"textColor":"charcoal-1","fontSize":"small"} /-->
 
 


### PR DESCRIPTION
See #59 

~At first, I was trying to add `.is-sticky` to [parent-2021](https://github.com/WordPress/wporg-parent-2021/blob/trunk/source/wp-content/themes/wporg-parent-2021/sass/block-styles.scss#L394), but I don't think that makes sense as the attributes assigned there should only be applied to `.is-style-brush-stroke.is-sticky` rather than `.is-sticky`. I'm thinking there might be other forms of `sticky` child theme would like to use, so I add it here first.~

~The mobile dropdown is broken after removing `is-style-brush-stroke`. Fixed [here](https://github.com/WordPress/wporg-parent-2021/pull/60).~

**Update**: Check out https://github.com/WordPress/wporg-parent-2021/pull/60#issuecomment-1331133075

## Screencast

https://user-images.githubusercontent.com/18050944/204383655-4a6166f6-90aa-4241-9a3f-2331581cad7a.mp4



