### PR TITLE
Stop loading large thumbnails.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -14,6 +14,8 @@
 <div class="wp-block-columns alignfull" style="padding-top:0"><!-- wp:column {"width":"60%","layout":{"type":"default"}} -->
 <div class="wp-block-column" style="flex-basis:60%"><!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
 <h1 class="screen-reader-text"><?php esc_attr_e( 'Showcase:', 'wporg' ); ?></h1>
+<!-- /wp:heading -->
+
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--30)"><!-- wp:image {"align":"full","id":7564,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image alignfull size-full"><img src="https://s.w.org/images/showcase/showcase.svg" alt="" class="wp-image-7564"/></figure>

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -14,8 +14,6 @@
 <div class="wp-block-columns alignfull" style="padding-top:0"><!-- wp:column {"width":"60%","layout":{"type":"default"}} -->
 <div class="wp-block-column" style="flex-basis:60%"><!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
 <h1 class="screen-reader-text"><?php esc_attr_e( 'Showcase:', 'wporg' ); ?></h1>
-<!-- /wp:heading -->
-
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-right:var(--wp--preset--spacing--30)"><!-- wp:image {"align":"full","id":7564,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image alignfull size-full"><img src="https://s.w.org/images/showcase/showcase.svg" alt="" class="wp-image-7564"/></figure>
@@ -37,7 +35,7 @@
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:wporg/site-screenshot {"isLink":true,"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} /--></div>
+<!-- wp:wporg/site-screenshot {"isLink":true,"useHiRes":true,"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 <!-- /wp:post-template --></div>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
@@ -12,6 +12,10 @@
 		"isLink": {
 			"type": "boolean",
 			"default": false
+		},
+		"useHiRes": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -24,7 +24,7 @@ function Edit( { attributes: { isLink, useHiRes }, setAttributes } ) {
 						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 					/>
 					<ToggleControl
-						label={ __( 'Use high resolution image.', 'wporg' ) }
+						label={ __( 'Use high resolution image', 'wporg' ) }
 						checked={ useHiRes }
 						onChange={ () => setAttributes( { useHiRes: ! useHiRes } ) }
 					/>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -13,7 +13,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import metadata from './block.json';
 import './style.scss';
 
-function Edit( { attributes: { isLink }, setAttributes } ) {
+function Edit( { attributes: { isLink, useHiRes }, setAttributes } ) {
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
@@ -22,6 +22,11 @@ function Edit( { attributes: { isLink }, setAttributes } ) {
 						label={ __( 'Make image link to Post', 'wporg' ) }
 						checked={ isLink }
 						onChange={ () => setAttributes( { isLink: ! isLink } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Use high resolution image.', 'wporg' ) }
+						checked={ useHiRes }
+						onChange={ () => setAttributes( { useHiRes: ! useHiRes } ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -51,7 +51,7 @@ function render( $attributes, $content, $block ) {
 		$screenshot = add_query_arg( 'scale', 2, $screenshot );
 	}
 
-	$img_content = "<img src='{$screenshot}' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' loading='lazy' />";
+	$img_content = "<img src='" . esc_url( $screenshot ) . "' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' loading='lazy' />";
 
 	if ( isset( $attributes['isLink'] ) && true == $attributes['isLink'] ) {
 		$img_content = '<a href="' . get_permalink( $post ) . '">' . $img_content . '</a>';

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -51,8 +51,6 @@ function render( $attributes, $content, $block ) {
 		$screenshot = add_query_arg( 'scale', 2, $screenshot );
 	}
 
-	$screenshot = add_query_arg( 'scale', 0.5, $screenshot );
-
 	$img_content = "<img src='{$screenshot}' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' loading='lazy' />";
 
 	if ( isset( $attributes['isLink'] ) && true == $attributes['isLink'] ) {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -46,7 +46,12 @@ function render( $attributes, $content, $block ) {
 	$post = get_post( $post_ID );
 
 	$screenshot = site_screenshot_src( $post );
-	$screenshot = add_query_arg( 'scale', 2, $screenshot );
+
+	if ( isset( $attributes['useHiRes'] ) && true === $attributes['useHiRes'] ) {
+		$screenshot = add_query_arg( 'scale', 2, $screenshot );
+	}
+
+	$screenshot = add_query_arg( 'scale', 0.5, $screenshot );
 
 	$img_content = "<img src='{$screenshot}' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' loading='lazy' />";
 

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
-<main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:wporg/site-screenshot {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
+<main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:wporg/site-screenshot {"align":"full","useHiRes":true,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
 	<!-- wp:pattern {"slug":"wporg-showcase-2022/page-single"} /-->
 </main>
 <!-- /wp:group -->


### PR DESCRIPTION
This PR introduces the ability to set the site-screenshot block to download a high resolution image, improving page performance. Currently, all images are loading with `scale=2` applied which doubles the size of the image. That resolution is only needed for the homepage hero image and the single view.

# Considerations
I played with using src-set to only use high-resolution images for set screenshots on `>= tablet` in [this branch](https://github.com/WordPress/wporg-showcase-2022/compare/fix/smaller-thumnail-images-srcset?expand=1), however, mShots considers them different photos and for some images there could be visible differences in the image.

**Example**
<img src="https://user-images.githubusercontent.com/1657336/204954768-4253d2c1-db7d-41a5-bd7e-7f35748e255a.gif" width="400" />

## How to test
1. Make sure you have cleared your front-page customizations
2. Load the front-page with Dev Tools network tab open (filter, search `scale=2`)
3. Expect to only see 1 image loaded with that query string
4. Navigate to archive, expect so see none
5. Click on site in archive, expect to see 1 image loaded.
