### PR TITLE
Hide the title if there are no related sites.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -23,9 +23,11 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
+<div id="wporg-related-posts" class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
 <h3 class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700"><?php esc_attr_e( 'Related sites', 'wporg' ); ?></h3>
 <!-- /wp:heading -->
 
 <!-- wp:jetpack/related-posts {"displayDate":false,"displayThumbnails":true} /--></div>
 <!-- /wp:group -->
+
+	

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -80,6 +80,15 @@
 }
 
 /*
+ * This hides the title if there are no related posts.
+ * Remove after: https://github.com/WordPress/wporg-showcase-2022/issues/68
+ */
+
+#wporg-related-posts h3:only-child {
+	display: none;
+}
+
+/*
  * JetPack Contact Form Styles
  */
 


### PR DESCRIPTION
This temporarily hides the `related posts` title while a better, long-term fix is worked on for https://github.com/WordPress/wporg-showcase-2022/issues/68.

The drawback here is that if more content is added in the container, this will break. For that reason, this cannot be considered a long-term fix. The best case is that the block itself handles the displaying/hiding of the title.

## Alternative CSS approaches
We could also use `h3:has( + { jetpack_container_id } )` but it's not supported in firefox. `only-child` has `97.49%` support according to caniuse.com, making it a better approach. 

## How to test
Need a sandbox.

1. Navigate to a site with no related posts (https://wordpress.org/showcase-test/2009/01/25/oregon-coast-visitors-association/), expect to **not** see the related posts title.
2. Navigate to other sites, and expect to see the related posts title. (https://wordpress.org/showcase-test/2009/03/23/we-heart-this/)