### PR TITLE
Fix heading levels.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -13,7 +13,7 @@
 <div class="wp-block-group has-charcoal-2-background-color has-background"><!-- wp:columns {"align":"full","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|40","left":"var:preset|spacing|40"},"padding":{"top":"0"}}}} -->
 <div class="wp-block-columns alignfull" style="padding-top:0"><!-- wp:column {"width":"60%","layout":{"type":"default"}} -->
 <div class="wp-block-column" style="flex-basis:60%"><!-- wp:heading {"level":1,"className":"screen-reader-text"} -->
-<h1 class="screen-reader-text"><?php esc_attr_e( 'Showcase:', 'wporg' ); ?></h1>
+<h1 class="screen-reader-text"><?php esc_attr_e( 'Showcase', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"right":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
@@ -28,11 +28,11 @@
 <div class="wp-block-group alignwide" style="padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--60)"><!-- wp:group {"align":"wide","className":"wporg-hero-details","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide wporg-hero-details"><!-- wp:group {"align":"full","layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
 <div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"default"}} -->
-<div class="wp-block-group"><!-- wp:paragraph {"align":"left","style":{"typography":{"lineHeight":"0"}},"textColor":"white","className":"is-style-serif"} -->
-<p class="has-text-align-left is-style-serif has-white-color has-text-color" style="line-height:0"><?php esc_attr_e( 'Featuring:', 'wporg' ); ?></p>
-<!-- /wp:paragraph -->
+<div class="wp-block-group"><!-- wp:heading {"textAlign":"left","style":{"typography":{"lineHeight":"0"}},"textColor":"white","className":"is-style-serif","fontSize":"extra-large"} -->
+<h2 class="has-text-align-left is-style-serif has-white-color has-text-color has-extra-large-font-size" style="line-height:0"><?php esc_attr_e( 'Featuring:', 'wporg' ); ?></h2>
+<!-- /wp:heading -->
 
-<!-- wp:post-title {"textAlign":"left","isLink":true,"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"italic","fontWeight":"400"}},"textColor":"white","fontSize":"extra-large","fontFamily":"eb-garamond"} /--></div>
+<!-- wp:post-title {"level":3,"textAlign":"left","isLink":true,"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"italic","fontWeight":"400"}},"textColor":"white","fontSize":"extra-large","fontFamily":"eb-garamond"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
@@ -62,7 +62,7 @@
 <div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;border-radius:2px"><!-- wp:wporg/site-screenshot {"align":"full","isLink":true} /--></div>
 <!-- /wp:group -->
 
-<!-- wp:post-title {"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"large","fontFamily":"inter"} /-->
+<!-- wp:post-title {"level":3,"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"large","fontFamily":"inter"} /-->
 <!-- /wp:post-template -->
 
 <!-- wp:query-no-results -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -7,7 +7,7 @@
 
 ?>
 
-<!-- wp:post-title {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-2"} /-->
+<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-2"} /-->
 
 <!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
 
@@ -23,8 +23,8 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
-<div id="wporg-related-posts" class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
-<h3 class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700"><?php esc_attr_e( 'Related sites', 'wporg' ); ?></h3>
+<div id="wporg-related-posts" class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
+<h2 class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700"><?php esc_attr_e( 'Related sites', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
 
 <!-- wp:jetpack/related-posts {"displayDate":false,"displayThumbnails":true} /--></div>

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit-confirmation.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit-confirmation.php
@@ -9,8 +9,8 @@
 
 <!-- wp:cover {"url":"https://s.w.org/wp-content/themes/wporg-showcase-2022/images/confetti.png?v=20221121","id":7789,"dimRatio":0,"isDark":false,"align":"full"} -->
 <div class="wp-block-cover alignfull is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><img class="wp-block-cover__image-background wp-image-7789" alt="" src="https://s.w.org/wp-content/themes/wporg-showcase-2022/images/confetti.png?v=20221121" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:group {"style":{"spacing":{"blockGap":"0px","padding":{"top":"var:preset|spacing|70","bottom":"var:preset|spacing|70"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:heading {"textAlign":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}}},"fontSize":"heading-3"} -->
-<h2 class="has-text-align-center has-heading-3-font-size" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'Your site has been submitted, thanks.', 'wporg' ); ?></h2>
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70)"><!-- wp:heading {"level":1,"textAlign":"center","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|20"}}},"fontSize":"heading-3"} -->
+<h1 class="has-text-align-center has-heading-3-font-size" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--20)"><?php esc_attr_e( 'Your site has been submitted, thanks.', 'wporg' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:group {"layout":{"type":"constrained","contentSize":"435px"}} -->


### PR DESCRIPTION
Closes #72.

This PR fixes heading levels for the following pages:
- Front-page
- Single
- Thanks

### Front-page
Page: https://wordpress.org/showcase-test
| Before | After | 
| --- | --- |
| <img width="337" alt="Screen Shot 2022-12-05 at 10 37 42 AM" src="https://user-images.githubusercontent.com/1657336/205533435-0826eeb3-219d-4553-b89b-e9ae2fb49703.png"> | <img width="338" alt="Screen Shot 2022-12-05 at 10 54 57 AM" src="https://user-images.githubusercontent.com/1657336/205533428-edcfdfe6-0e84-4a50-8979-4229506f5b1f.png"> |

### Single 
Page: https://wordpress.org/showcase-test/2019/10/07/vogue/
| Before | After | 
| --- | --- |
|  <img width="338" alt="Screen Shot 2022-12-05 at 11 04 19 AM" src="https://user-images.githubusercontent.com/1657336/205533586-368c4781-46eb-493c-afe1-ca1c5500ef86.png"> | <img width="337" alt="Screen Shot 2022-12-05 at 11 04 32 AM" src="https://user-images.githubusercontent.com/1657336/205533585-0a2c122a-5ca2-4991-ae59-b830c894d011.png"> |

###  Thanks
Page: https://wordpress.org/showcase-test/submit-a-wordpress-site/thanks
| Before | After | 
| --- | --- |
| <img width="330" alt="Screen Shot 2022-12-05 at 11 21 52 AM" src="https://user-images.githubusercontent.com/1657336/205535646-69371dec-1e8d-442d-9f0c-8a5ca8d76754.png"> | <img width="339" alt="Screen Shot 2022-12-05 at 11 21 37 AM" src="https://user-images.githubusercontent.com/1657336/205535651-40fcb0ae-b46e-4d2d-89c5-4e514a05654b.png"> |


## Questions

### Archives
We don't have a good candidate for an `<h1>` on archives though. We could make the context statement an `<h1>` I guess. 

**Any opinions?**

#### Current Page
<img width="500" alt="Screen Shot 2022-12-05 at 11 25 15 AM" src="https://user-images.githubusercontent.com/1657336/205535852-b642854b-291b-41fb-8874-1a368f147c55.png">

## Submit Site 
This should be fixed when https://github.com/WordPress/wporg-showcase-2022/issues/71 is closed.

