### PR TITLE
Update layout and add h1 tag to submit page.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-submit.php
@@ -7,6 +7,15 @@
 
 ?>
 
+<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"33.3%"} -->
+<div class="wp-block-column" style="flex-basis:33.3%"><!-- wp:heading {"level":1,"style":{"spacing":{"padding":{"right":"var:preset|spacing|60"}}},"fontSize":"heading-2"} -->
+<h1 class="has-heading-2-font-size" style="padding-right:var(--wp--preset--spacing--60)"><?php esc_attr_e( 'Submit a site', 'wporg' ); ?></h1>
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%">
 <!-- wp:paragraph -->
 <p><?php esc_attr_e( 'Thank you for your interest in the WordPress Showcase. The Showcase aims to show the world what can be done with WordPress and help demonstrate that WordPress has tremendous capabilities as a publishing platform. Submitting a site for review is quick and easy to do.', 'wporg' ); ?></p>
 <!-- /wp:paragraph -->
@@ -78,4 +87,6 @@ _e( 'While only a relatively small number of submissions are eventually added to
 <!-- wp:jetpack/field-checkbox {"label":"<?php esc_attr_e( 'Check this box if you own the site and agree to be contacted by email', 'wporg' ); ?>"} /-->
 
 <!-- wp:jetpack/button {"element":"button","text":"<?php esc_attr_e( 'Submit site', 'wporg' ); ?>","lock":{"remove":true}} /--></div>
-<!-- /wp:jetpack/contact-form -->
+<!-- /wp:jetpack/contact-form --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
This PR adds a title to `/submit-a-wordpress-site`. This uses the same approach as the [releases page](https://github.com/WordPress/wporg-main-2022/blob/trunk/source/wp-content/themes/wporg-main-2022/patterns/download-releases.php). 

One thing to note is that on a tablet the title wraps onto a new line. I think this is ok seeing that having less custom CSS is a better outcome.

Closes: #71

## Screenshots

| Mobile | Tablet | Desktop |
| --- | --- | --- |
| ![localhost_8888_submit-a-wordpress-site_(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/1657336/205545170-5efc29dd-0e17-499c-b7d1-26f9f66efe5b.png) | ![localhost_8888_submit-a-wordpress-site_(iPad Air) (1)](https://user-images.githubusercontent.com/1657336/205545165-a1067e6d-e533-48e4-b983-48d33841c27b.png) | ![localhost_8888_submit-a-wordpress-site_ (3)](https://user-images.githubusercontent.com/1657336/205545160-21f9f011-c396-40a9-9547-813e6a254cf7.png) |  


