### PR TITLE
Fix document titles

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -16,6 +16,7 @@ add_action( 'template_redirect', __NAMESPACE__ . '\redirect_urls' );
 add_filter( 'jetpack_images_get_images', __NAMESPACE__ . '\jetpack_fallback_image', 10, 3 );
 add_filter( 'jetpack_relatedposts_filter_thumbnail_size', __NAMESPACE__ . '\jetpackchange_image_size' );
 add_filter( 'jetpack_relatedposts_filter_headline', __NAMESPACE__ . '\jetpackme_related_posts_headline' );
+add_filter( 'document_title_parts', __NAMESPACE__ . '\document_title' );
 add_filter( 'excerpt_length', __NAMESPACE__ . '\modify_excerpt_length', 999 );
 add_filter( 'excerpt_more', __NAMESPACE__ . '\modify_excerpt_more' );
 add_filter( 'query_loop_block_query_vars', __NAMESPACE__ . '\modify_query_loop_block_query_vars', 10, 2 );
@@ -256,4 +257,49 @@ function set_noindex( $noindex ) {
 function set_site_breadcrumbs( $breadcrumbs ) {
 	$breadcrumbs[0]['title'] = __( 'Showcase', 'wporg' );
 	return $breadcrumbs;
+}
+
+
+/**
+ * Append an optimized site name.
+ *
+ * @param array $title {
+ *     The document title parts.
+ *
+ *     @type string $title   Title of the viewed page.
+ *     @type string $page    Optional. Page number if paginated.
+ *     @type string $tagline Optional. Site description when on home page.
+ *     @type string $site    Optional. Site title when not on home page.
+ * }
+ * @return array Filtered title parts.
+ */
+function document_title( $title ) {
+	global $wp_query;
+
+	if ( is_front_page() ) {
+		$title['title']   = __( 'WordPress Showcase', 'wporg' );
+		$title['tagline'] = __( 'WordPress.org', 'wporg' );
+	} else {
+		if ( is_single() ) {
+			$title['title'] .= ' - ' . __( 'WordPress Showcase', 'wporg' );
+		} elseif ( is_tag() ) {
+			$title['title'] = sprintf( __( 'Sites tagged as "%s"', 'wporg' ), strtolower( $title['title'] ) );
+		} elseif ( is_category() ) {
+			$title['title'] = sprintf( __( 'Sites categorized as "%s"', 'wporg' ), strtolower( $title['title'] ) );
+		}
+
+		// If results are paged and the max number of pages is known.
+		if ( is_paged() && $wp_query->max_num_pages ) {
+			// translators: 1: current page number, 2: total number of pages
+			$title['page'] = sprintf(
+				__( 'Page %1$s of %2$s', 'wporg' ),
+				get_query_var( 'paged' ),
+				$wp_query->max_num_pages
+			);
+		}
+
+		$title['site'] = __( 'WordPress.org', 'wporg' );
+	}
+
+	return $title;
 }

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -259,7 +259,6 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 	return $breadcrumbs;
 }
 
-
 /**
  * Append an optimized site name.
  *

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -263,10 +263,10 @@ function set_site_breadcrumbs( $breadcrumbs ) {
 /**
  * Append an optimized site name.
  *
- * @param array $title {
+ * @param array $parts {
  *     The document title parts.
  *
- *     @type string $parts   Title of the viewed page.
+ *     @type string $title   Title of the viewed page.
  *     @type string $page    Optional. Page number if paginated.
  *     @type string $tagline Optional. Site description when on home page.
  *     @type string $site    Optional. Site title when not on home page.
@@ -281,17 +281,20 @@ function document_title( $parts ) {
 		$parts['tagline'] = __( 'WordPress.org', 'wporg' );
 	} else {
 		if ( is_single() ) {
-			$parts['title'] = sprintf( esc_attr__( '%s - WordPress Showcase', 'wporg-showcase' ), esc_attr( $parts['title'] ) );
+			// translators: %s: Name of the site
+			$parts['title'] = sprintf( __( '%s - WordPress Showcase', 'wporg' ), esc_attr( $parts['title'] ) );
 		} elseif ( is_tag() ) {
+			// translators: %s: The name of the tag
 			$parts['title'] = sprintf( __( 'Sites tagged as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
 		} elseif ( is_category() ) {
+			// translators: %s: The name of the tag
 			$parts['title'] = sprintf( __( 'Sites categorized as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
 		}
 
 		// If results are paged and the max number of pages is known.
 		if ( is_paged() && $wp_query->max_num_pages ) {
-			// translators: 1: current page number, 2: total number of pages
 			$parts['page'] = sprintf(
+				// translators: 1: current page number, 2: total number of pages
 				__( 'Page %1$s of %2$s', 'wporg' ),
 				get_query_var( 'paged' ),
 				$wp_query->max_num_pages

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -266,42 +266,42 @@ function set_site_breadcrumbs( $breadcrumbs ) {
  * @param array $title {
  *     The document title parts.
  *
- *     @type string $title   Title of the viewed page.
+ *     @type string $parts   Title of the viewed page.
  *     @type string $page    Optional. Page number if paginated.
  *     @type string $tagline Optional. Site description when on home page.
  *     @type string $site    Optional. Site title when not on home page.
  * }
  * @return array Filtered title parts.
  */
-function document_title( $title ) {
+function document_title( $parts ) {
 	global $wp_query;
 
 	if ( is_front_page() ) {
-		$title['title']   = $title['tagline'];
-		$title['tagline'] = __( 'WordPress.org', 'wporg' );
+		$parts['title']   = $parts['tagline'];
+		$parts['tagline'] = __( 'WordPress.org', 'wporg' );
 	} else {
 		if ( is_single() ) {
-			$title['title'] = sprintf( esc_attr__( '%s Showcase', 'wporg-showcase' ), esc_attr( $title['title'] ) );
+			$parts['title'] = sprintf( esc_attr__( '%s Showcase', 'wporg-showcase' ), esc_attr( $parts['title'] ) );
 		} elseif ( is_tag() ) {
-			$title['title'] = sprintf( __( 'Sites tagged as "%s"', 'wporg' ), strtolower( $title['title'] ) );
+			$parts['title'] = sprintf( __( 'Sites tagged as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
 		} elseif ( is_category() ) {
-			$title['title'] = sprintf( __( 'Sites categorized as "%s"', 'wporg' ), strtolower( $title['title'] ) );
+			$parts['title'] = sprintf( __( 'Sites categorized as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
 		}
 
 		// If results are paged and the max number of pages is known.
 		if ( is_paged() && $wp_query->max_num_pages ) {
 			// translators: 1: current page number, 2: total number of pages
-			$title['page'] = sprintf(
+			$parts['page'] = sprintf(
 				__( 'Page %1$s of %2$s', 'wporg' ),
 				get_query_var( 'paged' ),
 				$wp_query->max_num_pages
 			);
 		}
 
-		$title['site'] = __( 'WordPress.org', 'wporg' );
+		$parts['site'] = __( 'WordPress.org', 'wporg' );
 	}
 
-	return $title;
+	return $parts;
 }
 
 /**

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -277,11 +277,11 @@ function document_title( $title ) {
 	global $wp_query;
 
 	if ( is_front_page() ) {
-		$title['title']   = __( 'WordPress Showcase', 'wporg' );
+		$title['title']   = $title['tagline'];
 		$title['tagline'] = __( 'WordPress.org', 'wporg' );
 	} else {
 		if ( is_single() ) {
-			$title['title'] .= ' - ' . __( 'WordPress Showcase', 'wporg' );
+			$title['title'] = sprintf( esc_attr__( '%s Showcase', 'wporg-showcase' ), esc_attr( $title['title'] ) );
 		} elseif ( is_tag() ) {
 			$title['title'] = sprintf( __( 'Sites tagged as "%s"', 'wporg' ), strtolower( $title['title'] ) );
 		} elseif ( is_category() ) {

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -282,7 +282,7 @@ function document_title( $parts ) {
 	} else {
 		if ( is_single() ) {
 			// translators: %s: Name of the site
-			$parts['title'] = sprintf( __( '%s - WordPress Showcase', 'wporg' ), esc_attr( $parts['title'] ) );
+			$parts['title'] = sprintf( __( '%s - WordPress Showcase', 'wporg' ), $parts['title'] );
 		} elseif ( is_tag() ) {
 			// translators: %s: The name of the tag
 			$parts['title'] = sprintf( __( 'Sites tagged as "%s"', 'wporg' ), strtolower( $parts['title'] ) );

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -17,6 +17,7 @@ add_filter( 'jetpack_images_get_images', __NAMESPACE__ . '\jetpack_fallback_imag
 add_filter( 'jetpack_relatedposts_filter_thumbnail_size', __NAMESPACE__ . '\jetpackchange_image_size' );
 add_filter( 'jetpack_relatedposts_filter_headline', __NAMESPACE__ . '\jetpackme_related_posts_headline' );
 add_filter( 'document_title_parts', __NAMESPACE__ . '\document_title' );
+add_filter( 'document_title_separator', __NAMESPACE__ . '\document_title_separator' );
 add_filter( 'excerpt_length', __NAMESPACE__ . '\modify_excerpt_length', 999 );
 add_filter( 'excerpt_more', __NAMESPACE__ . '\modify_excerpt_more' );
 add_filter( 'query_loop_block_query_vars', __NAMESPACE__ . '\modify_query_loop_block_query_vars', 10, 2 );
@@ -301,4 +302,14 @@ function document_title( $title ) {
 	}
 
 	return $title;
+}
+
+/**
+ * Change document title separator
+ *
+ * @param string $title
+ * @return string
+ */
+function document_title_separator( $title ) {
+	return '&#124;';
 }

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -281,7 +281,7 @@ function document_title( $parts ) {
 		$parts['tagline'] = __( 'WordPress.org', 'wporg' );
 	} else {
 		if ( is_single() ) {
-			$parts['title'] = sprintf( esc_attr__( '%s Showcase', 'wporg-showcase' ), esc_attr( $parts['title'] ) );
+			$parts['title'] = sprintf( esc_attr__( '%s - WordPress Showcase', 'wporg-showcase' ), esc_attr( $parts['title'] ) );
 		} elseif ( is_tag() ) {
 			$parts['title'] = sprintf( __( 'Sites tagged as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
 		} elseif ( is_category() ) {


### PR DESCRIPTION
Closes #77.

This PR reimplements some of [document title logic ](https://github.com/WordPress/wordpress.org/blob/a82a685677217f833ef477ffd7bef1590cbc3b83/wordpress.org/public_html/wp-content/themes/pub/wporg-showcase/functions.php#L263)from the original wporg-showcase theme along with some improvements taken from the [plugin theme for paging results](https://github.com/WordPress/wordpress.org/blob/a82a685677217f833ef477ffd7bef1590cbc3b83/wordpress.org/public_html/wp-content/themes/pub/wporg-plugins/functions.php#L276).

| Page | Title |
| --- | --- | 
| Front Page | `The Best WordPress Sites in the World \| WordPress.org` |
| Single | `The Modern House - WordPress Showcase \| WordPress.org` |
| Tag | `Sites tagged as “adventure” \| WordPress.org` |
| Category  | `Sites categorized as “uncategorized” \| WordPress.org` |
| Search | `Search Results for “c” \| WordPress.org` |
| Search Paged  | `Search Results for “c” \| Page 3 of 40 \| WordPress.org` |
| Page  | `Submit a site \| WordPress.org` |