### PR TITLE
Update site-screenshot to allow setting lazy loading.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/archive-content.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/archive-content.php
@@ -15,7 +15,7 @@
 	<div class="wp-block-query"><!-- wp:post-template -->
 	
 	<!-- wp:group {"style":{"border":{"width":"1px","radius":"2px"}},"borderColor":"light-grey-1"} -->
-	<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;border-radius:2px"><!-- wp:wporg/site-screenshot {"isLink":true} /--></div>
+	<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;border-radius:2px"><!-- wp:wporg/site-screenshot {"isLink":true,"lazyLoad":true} /--></div>
 	<!-- /wp:group -->
 	
 	<!-- wp:post-title {"isLink":true,"fontSize":"normal","fontFamily":"inter"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -59,7 +59,7 @@
 <!-- wp:query {"queryId":16,"query":{"perPage":20,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[8]}},"displayLayout":{"type":"flex","columns":2}} -->
 <div class="wp-block-query"><!-- wp:post-template -->
 <!-- wp:group {"style":{"border":{"width":"1px","radius":"2px"}},"borderColor":"light-grey-1","layout":{"type":"constrained"}} -->
-<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;border-radius:2px"><!-- wp:wporg/site-screenshot {"align":"full","isLink":true} /--></div>
+<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-width:1px;border-radius:2px"><!-- wp:wporg/site-screenshot {"align":"full","isLink":true,"lazyLoad":true} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:post-title {"isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
@@ -16,6 +16,10 @@
 		"useHiRes": {
 			"type": "boolean",
 			"default": false
+		},
+		"lazyLoad": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -13,7 +13,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import metadata from './block.json';
 import './style.scss';
 
-function Edit( { attributes: { isLink, useHiRes }, setAttributes } ) {
+function Edit( { attributes: { isLink, useHiRes, lazyLoad }, setAttributes } ) {
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
@@ -27,6 +27,11 @@ function Edit( { attributes: { isLink, useHiRes }, setAttributes } ) {
 						label={ __( 'Use high resolution image', 'wporg' ) }
 						checked={ useHiRes }
 						onChange={ () => setAttributes( { useHiRes: ! useHiRes } ) }
+					/>
+					<ToggleControl
+						label={ __( 'Lazy load image', 'wporg' ) }
+						checked={ lazyLoad }
+						onChange={ () => setAttributes( { lazyLoad: ! lazyLoad } ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -51,7 +51,12 @@ function render( $attributes, $content, $block ) {
 		$screenshot = add_query_arg( 'scale', 2, $screenshot );
 	}
 
-	$img_content = "<img src='" . esc_url( $screenshot ) . "' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' loading='lazy' />";
+	$loading = 'eager';
+	if ( isset( $attributes['lazyLoad'] ) && true === $attributes['lazyLoad'] ) {
+		$loading = 'lazy';
+	}
+
+	$img_content = "<img src='" . esc_url( $screenshot ) . "' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' loading='" . esc_html( $loading ) . "' />";
 
 	if ( isset( $attributes['isLink'] ) && true == $attributes['isLink'] ) {
 		$img_content = '<a href="' . get_permalink( $post ) . '">' . $img_content . '</a>';

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -56,7 +56,7 @@ function render( $attributes, $content, $block ) {
 		$loading = 'lazy';
 	}
 
-	$img_content = "<img src='" . esc_url( $screenshot ) . "' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' loading='" . esc_html( $loading ) . "' />";
+	$img_content = "<img src='" . esc_url( $screenshot ) . "' alt='" . the_title_attribute( array( 'echo' => false ) ) . "' loading='" . esc_attr( $loading ) . "' />";
 
 	if ( isset( $attributes['isLink'] ) && true == $attributes['isLink'] ) {
 		$img_content = '<a href="' . get_permalink( $post ) . '">' . $img_content . '</a>';


### PR DESCRIPTION
Closes: #75 

Currently, all images that use `site-screenshot` are lazy loaded. This delays the first paint of the page needlessly. We should not have it lazy loading on images that we are sure will show up on the viewport on load. We have 2 such images -- front page, single. 

This PR makes lazy loading a property to pass into the block, assuming default as the initial state, matching the default `<img>` behavior. 

**Performance**
Reduces `Largest Contentful Paint` on average by `~300ms`

**Block Editor View**
<img width="282" alt="Screen Shot 2022-12-06 at 11 21 03 AM" src="https://user-images.githubusercontent.com/1657336/205792869-aec5d80d-ac39-41a5-80a0-8551898913f0.png">

