### PR TITLE
Try/configurable archive context tag

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/results-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/results-bar.php
@@ -9,7 +9,7 @@
 
 <!-- wp:columns {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-columns are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:column {"verticalAlignment":"center","width":""} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:wporg/archive-results-context /--></div>
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:wporg/archive-results-context {"fontSize":"normal","fontFamily":"inter"} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"302px"} -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/results-bar.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/results-bar.php
@@ -9,7 +9,7 @@
 
 <!-- wp:columns {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
 <div class="wp-block-columns are-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40)"><!-- wp:column {"verticalAlignment":"center","width":""} -->
-<div class="wp-block-column is-vertically-aligned-center"><!-- wp:wporg/archive-results-context {"fontSize":"normal","fontFamily":"inter"} /--></div>
+<div class="wp-block-column is-vertically-aligned-center"><!-- wp:wporg/archive-results-context {"tagName":"h1","fontSize":"normal","fontFamily":"inter"} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"302px"} -->

--- a/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/block.json
@@ -8,7 +8,12 @@
 	"icon": "",
 	"description": "Displays context information for archive or search results.",
 	"textdomain": "wporg",
-	"attributes": {},
+	"attributes": {
+		"tagName": {
+			"type": "string",
+			"default": "p"
+		}
+	},
 	"supports": {
 		"align": true,
 		"color": true,
@@ -17,6 +22,21 @@
 			"margin": true,
 			"padding": true,
 			"blockGap": false
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true,
+				"fontAppearance": true,
+				"textTransform": true
+			}
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/index.js
@@ -1,7 +1,10 @@
 /**
  * WordPress dependencies
  */
+import { InspectorControls } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import ServerSideRender from '@wordpress/server-side-render';
 
 /**
@@ -9,8 +12,48 @@ import ServerSideRender from '@wordpress/server-side-render';
  */
 import metadata from './block.json';
 
-function Edit( { attributes, name } ) {
-	return <ServerSideRender block={ name } attributes={ attributes } />;
+/**
+ * Render inspector controls.
+ *
+ * @param {Object}   props                 Component props.
+ * @param {string}   props.tagName         The HTML tag name.
+ * @param {Function} props.onSelectTagName onChange function for the SelectControl.
+ *
+ * @return {JSX.Element}                The control group.
+ */
+function GroupEditControls( { tagName, onSelectTagName } ) {
+	return (
+		<InspectorControls __experimentalGroup="advanced">
+			<SelectControl
+				label={ __( 'HTML element', 'wporg' ) }
+				options={ [
+					{ label: __( 'Default (<p>)', 'wporg' ), value: 'p' },
+					{ label: '<div>', value: 'div' },
+					{ label: '<h1>', value: 'h1' },
+					{ label: '<h2>', value: 'h2' },
+					{ label: '<h3>', value: 'h3' },
+					{ label: '<h4>', value: 'h4' },
+					{ label: '<h5>', value: 'h5' },
+					{ label: '<h6>', value: 'h6' },
+				] }
+				value={ tagName }
+				onChange={ onSelectTagName }
+			/>
+		</InspectorControls>
+	);
+}
+
+function Edit( { attributes, setAttributes, name } ) {
+	const { tagName } = attributes;
+	return (
+		<>
+			<GroupEditControls
+				tagName={ tagName }
+				onSelectTagName={ ( val ) => setAttributes( { tagName: val } ) }
+			/>
+			<ServerSideRender block={ name } attributes={ attributes } />
+		</>
+	);
 }
 
 registerBlockType( metadata.name, {

--- a/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/index.js
@@ -12,45 +12,27 @@ import ServerSideRender from '@wordpress/server-side-render';
  */
 import metadata from './block.json';
 
-/**
- * Render inspector controls.
- *
- * @param {Object}   props                 Component props.
- * @param {string}   props.tagName         The HTML tag name.
- * @param {Function} props.onSelectTagName onChange function for the SelectControl.
- *
- * @return {JSX.Element}                The control group.
- */
-function GroupEditControls( { tagName, onSelectTagName } ) {
-	return (
-		<InspectorControls __experimentalGroup="advanced">
-			<SelectControl
-				label={ __( 'HTML element', 'wporg' ) }
-				options={ [
-					{ label: __( 'Default (<p>)', 'wporg' ), value: 'p' },
-					{ label: '<div>', value: 'div' },
-					{ label: '<h1>', value: 'h1' },
-					{ label: '<h2>', value: 'h2' },
-					{ label: '<h3>', value: 'h3' },
-					{ label: '<h4>', value: 'h4' },
-					{ label: '<h5>', value: 'h5' },
-					{ label: '<h6>', value: 'h6' },
-				] }
-				value={ tagName }
-				onChange={ onSelectTagName }
-			/>
-		</InspectorControls>
-	);
-}
-
 function Edit( { attributes, setAttributes, name } ) {
 	const { tagName } = attributes;
 	return (
 		<>
-			<GroupEditControls
-				tagName={ tagName }
-				onSelectTagName={ ( val ) => setAttributes( { tagName: val } ) }
-			/>
+			<InspectorControls __experimentalGroup="advanced">
+				<SelectControl
+					label={ __( 'HTML element', 'wporg' ) }
+					options={ [
+						{ label: __( 'Default (<p>)', 'wporg' ), value: 'p' },
+						{ label: '<div>', value: 'div' },
+						{ label: '<h1>', value: 'h1' },
+						{ label: '<h2>', value: 'h2' },
+						{ label: '<h3>', value: 'h3' },
+						{ label: '<h4>', value: 'h4' },
+						{ label: '<h5>', value: 'h5' },
+						{ label: '<h6>', value: 'h6' },
+					] }
+					value={ tagName }
+					onChange={ ( val ) => setAttributes( { tagName: val } ) }
+				/>
+			</InspectorControls>
 			<ServerSideRender block={ name } attributes={ attributes } />
 		</>
 	);

--- a/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/index.php
@@ -59,7 +59,7 @@ function render( $attributes ) {
 			/* translators: %1$s number of results */
 			_n(
 				'There is <b>%1$s</b> site in the archive',
-				'<p>There are <b>%1$s</b> sites in the archive',
+				'There are <b>%1$s</b> sites in the archive',
 				$wp_query->found_posts,
 				'wporg'
 			),

--- a/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/archive-results-context/index.php
@@ -15,15 +15,15 @@ add_action( 'init', __NAMESPACE__ . '\init' );
  *
  * @return string Returns the block markup.
  */
-function render() {
+function render( $attributes ) {
 	global $wp_query;
 
 	if ( is_search() ) {
 		$content = sprintf(
 			/* translators: %1$s number of results; %2$s keyword. */
 			_n(
-				'<p>We found <b>%1$s</b> result for <b>%2$s</b></p>',
-				'<p>We found <b>%1$s</b> results for <b>%2$s</b></p>',
+				'We found <b>%1$s</b> result for <b>%2$s</b>',
+				'We found <b>%1$s</b> results for <b>%2$s</b>',
 				$wp_query->found_posts,
 				'wporg'
 			),
@@ -34,8 +34,8 @@ function render() {
 		$content = sprintf(
 			/* translators: %1$s number of results; %2$s tag. */
 			_n(
-				'<p>There is <b>%1$s</b> site tagged with <b>%2$s</b></p>',
-				'<p>There are <b>%1$s</b> sites tagged with <b>%2$s</b></p>',
+				'There is <b>%1$s</b> site tagged with <b>%2$s</b>',
+				'There are <b>%1$s</b> sites tagged with <b>%2$s</b>',
 				$wp_query->found_posts,
 				'wporg'
 			),
@@ -46,8 +46,8 @@ function render() {
 		$content = sprintf(
 			/* translators: %1$s number of results; %2$s category. */
 			_n(
-				'<p>There is <b>%1$s</b> site categorized as <b>%2$s</b></p>',
-				'<p>There are <b>%1$s</b> sites categorized as <b>%2$s</b></p>',
+				'There is <b>%1$s</b> site categorized as <b>%2$s</b>',
+				'There are <b>%1$s</b> sites categorized as <b>%2$s</b>',
 				$wp_query->found_posts,
 				'wporg'
 			),
@@ -58,8 +58,8 @@ function render() {
 		$content = sprintf(
 			/* translators: %1$s number of results */
 			_n(
-				'<p>There is <b>%1$s</b> site in the archive</p>',
-				'<p>There are <b>%1$s</b> sites in the archive</p>',
+				'There is <b>%1$s</b> site in the archive',
+				'<p>There are <b>%1$s</b> sites in the archive',
 				$wp_query->found_posts,
 				'wporg'
 			),
@@ -70,7 +70,8 @@ function render() {
 	$wrapper_attributes = get_block_wrapper_attributes();
 
 	return sprintf(
-		'<div %s>%s</div>',
+		'<%1$s %2$s>%3$s</%1$s>',
+		esc_attr( $attributes['tagName'] ),
 		$wrapper_attributes,
 		$content
 	);


### PR DESCRIPTION
Closes #86.

This PR updates the archive context control to make the tag configurable so we can update it to an `<h1>`. This also incidentally updates the template.

Note: This PR borrows some code from the [Gutenberg group block](https://github.com/WordPress/gutenberg/blob/22239e643ca8768ecc76b3261bcc3bcc5eeb1b3e/packages/block-library/src/group/edit.js#L31) to allow users to select the tag that will be used.

## Screenshots
### Block Editor Settings
<img width="282" alt="Screen Shot 2022-12-07 at 3 12 38 PM" src="https://user-images.githubusercontent.com/1657336/206102388-d151357c-3db1-49bb-b0a0-3c1237a323a9.png">

## How to Test
1. Open the site editor and find the archive template.
2. Select the `archive-results-context` block.
3. Expect to see all settings described in [block.json](https://github.com/WordPress/wporg-showcase-2022/compare/try/configurable-archive-context-tag?expand=1#diff-96670df29bcf4c1991da53ffa3138176044eb73d4d74ae836c7bf18430479005R25)
4. Play with the settings and verify they are applied
5. Change the tag via the new select menu in the advanced section.
6. Save the template, view the template and expect that it uses that tag to render the context string.