### PR TITLE
Add a shortcode to display the number of sites in the archive.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/shortcodes.php
@@ -37,7 +37,7 @@ add_shortcode(
 );
 
 /**
- * Returns the number of published sites in archive.
+ * Returns the number of published posts.
  */
 add_shortcode(
 	'sites_in_archive_count',

--- a/source/wp-content/themes/wporg-showcase-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/shortcodes.php
@@ -35,3 +35,13 @@ add_shortcode(
 		return str_replace( 'www.', '', parse_url( $values[0], PHP_URL_HOST ) );
 	}
 );
+
+/**
+ * Returns the number of published sites in archive.
+ */
+add_shortcode(
+	'sites_in_archive_count',
+	function() {
+		return wp_count_posts()->publish;
+	}
+);

--- a/source/wp-content/themes/wporg-showcase-2022/inc/shortcodes.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/shortcodes.php
@@ -35,13 +35,3 @@ add_shortcode(
 		return str_replace( 'www.', '', parse_url( $values[0], PHP_URL_HOST ) );
 	}
 );
-
-/**
- * Returns the number of published posts.
- */
-add_shortcode(
-	'sites_in_archive_count',
-	function() {
-		return wp_count_posts()->publish;
-	}
-);

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -74,7 +74,7 @@
 
 <!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60)"><!-- wp:button {"backgroundColor":"white","textColor":"blueberry-1","className":"is-style-outline","fontSize":"normal"} -->
-<div class="wp-block-button has-custom-font-size is-style-outline has-normal-font-size"><a class="wp-block-button__link has-blueberry-1-color has-white-background-color has-text-color has-background wp-element-button" href="https://wordpress.org/showcase/archives"><?php esc_attr_e( 'Browse the archive', 'wporg' ); ?></a></div>
+<div class="wp-block-button has-custom-font-size is-style-outline has-normal-font-size"><a class="wp-block-button__link has-blueberry-1-color has-white-background-color has-text-color has-background wp-element-button" href="https://wordpress.org/showcase/archives"><?php esc_attr_e( 'Browse [sites_in_archive_count] sites in the archive', 'wporg' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -77,14 +77,16 @@
 <div class="wp-block-button has-custom-font-size is-style-outline has-normal-font-size">
 	<a class="wp-block-button__link has-blueberry-1-color has-white-background-color has-text-color has-background wp-element-button" href="https://wordpress.org/showcase/archives">
 		<?php printf(
-			/* translators: %d number of sites */
-			_n(
-				'Browse %d site in the archive',
-				'Browse %d sites in the archive',
-				wp_count_posts()->publish,
-				'wporg'
+			esc_attr(
+				/* translators: %d number of sites */
+				_n(
+					'Browse %d site in the archive',
+					'Browse %d sites in the archive',
+					wp_count_posts()->publish,
+					'wporg'
+				)
 			),
-			number_format_i18n( wp_count_posts()->publish )
+			esc_attr( number_format_i18n( wp_count_posts()->publish ) )
 		); ?></a>
 </div>
 <!-- /wp:button --></div>

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -74,7 +74,19 @@
 
 <!-- wp:buttons {"style":{"spacing":{"margin":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60"}}}} -->
 <div class="wp-block-buttons" style="margin-top:var(--wp--preset--spacing--60);margin-bottom:var(--wp--preset--spacing--60)"><!-- wp:button {"backgroundColor":"white","textColor":"blueberry-1","className":"is-style-outline","fontSize":"normal"} -->
-<div class="wp-block-button has-custom-font-size is-style-outline has-normal-font-size"><a class="wp-block-button__link has-blueberry-1-color has-white-background-color has-text-color has-background wp-element-button" href="https://wordpress.org/showcase/archives"><?php esc_attr_e( 'Browse [sites_in_archive_count] sites in the archive', 'wporg' ); ?></a></div>
+<div class="wp-block-button has-custom-font-size is-style-outline has-normal-font-size">
+	<a class="wp-block-button__link has-blueberry-1-color has-white-background-color has-text-color has-background wp-element-button" href="https://wordpress.org/showcase/archives">
+		<?php printf(
+			/* translators: %d number of sites */
+			_n(
+				'Browse %d site in the archive',
+				'Browse %d sites in the archive',
+				wp_count_posts()->publish,
+				'wporg'
+			),
+			number_format_i18n( wp_count_posts()->publish )
+		); ?></a>
+</div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Closes: #94 

This PR adds a shortcode to retrieve the number of published posts to be used within a link on the front page.

| Before | After |
 | --- | --- |
| <img width="289" alt="Screen Shot 2022-12-09 at 10 14 56 AM" src="https://user-images.githubusercontent.com/1657336/206600714-3c0c5142-d5cb-4558-83d7-2c2e7981d199.png"> | <img width="415" alt="Screen Shot 2022-12-09 at 10 13 38 AM" src="https://user-images.githubusercontent.com/1657336/206600717-d01eb1da-919d-4b12-abb3-06078319f854.png"> |

