### PR TITLE
Fix site meta list spacing on very small screens

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -4,7 +4,7 @@
 
 .wp-block-wporg-site-meta-list dl > div {
 	display: grid;
-	grid-template-columns: 0.6fr 1fr;
+	grid-template-columns: 1fr 1fr;
 }
 
 .wp-block-wporg-site-meta-list dd {
@@ -14,6 +14,17 @@
 
 .wp-block-wporg-site-meta-list dl > div:last-child dd:last-child {
 	margin-bottom: 0;
+}
+
+.wp-block-wporg-site-meta-list dt {
+	white-space: nowrap;
+	padding-right: 1rem;
+}
+
+@media (min-width: 390px) {
+	.wp-block-wporg-site-meta-list dl > div {
+		grid-template-columns: 0.6fr 1fr;
+	}
 }
 
 @media (min-width: 641px) {


### PR DESCRIPTION
Fixes #97 

Render the meta data in a 1:1 grid at very small sizes, and stop the label breaking to 2 lines.

| Very small | Small | Tablet |
|-|-|-|
| ![Screen Shot 2022-12-12 at 3 08 49 PM](https://user-images.githubusercontent.com/1017872/206946330-9cbe7842-d353-49d5-83bc-bf27a4df1627.jpg) | ![Screen Shot 2022-12-12 at 3 09 02 PM](https://user-images.githubusercontent.com/1017872/206946355-568ce7ff-9fa9-4ae3-89e3-3bfee4779e3f.jpg) | ![Screen Shot 2022-12-12 at 3 09 23 PM](https://user-images.githubusercontent.com/1017872/206946372-cd705a47-cccf-43e0-aa4a-760e00fe2928.jpg) |