### PR TITLE
Move site link under title.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -7,14 +7,12 @@
 
 ?>
 
-<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-2"} /-->
-
-<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
-
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"className":"external-link"} -->
-<p class="external-link" style="margin-top:var(--wp--preset--spacing--20)"><a href="[domain]" target="_blank" rel="noopener noreferrer">[pretty_domain]</a></p>
+<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"}}},"fontSize":"heading-2"} /-->
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"className":"external-link"} -->
+<p class="external-link" style="margin-bottom:var(--wp--preset--spacing--30)"><a href="[domain]" target="_blank" rel="noopener noreferrer">[pretty_domain]</a></p>
 <!-- /wp:paragraph -->
 
+<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|30"}},"border":{"radius":"2px"}},"backgroundColor":"blueberry-4"} -->
 <div class="wp-block-group has-blueberry-4-background-color has-background" style="border-radius:2px;margin-top:var(--wp--preset--spacing--30);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"normal","fontFamily":"inter"} -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -8,8 +8,8 @@
 ?>
 
 <!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"}}},"fontSize":"heading-2"} /-->
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"className":"external-link"} -->
-<p class="external-link" style="margin-bottom:var(--wp--preset--spacing--30)"><a href="[domain]" target="_blank" rel="noopener noreferrer">[pretty_domain]</a></p>
+<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"},"padding":{"bottom":"var:preset|spacing|10"}}},"className":"external-link"} -->
+<p class="external-link" style="margin-bottom:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10)"><a href="[domain]" target="_blank" rel="noopener noreferrer">[pretty_domain]</a></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->


### PR DESCRIPTION
Fixes: #109.

This PR moves the site URL under the post-title. I have opened this as a PR because the figma designs do not include the external link icon but it was made a .org requirement. I want to surface that before this change merges. 

| Design | Implementation |
 |--- | --- |
| <img width="400" alt="Screen Shot 2022-12-15 at 9 03 07 AM" src="https://user-images.githubusercontent.com/1657336/207741476-442a4dc0-2769-48b3-bfc4-e6ec0be23c53.png"> | <img width="400" alt="Screen Shot 2022-12-15 at 9 06 24 AM" src="https://user-images.githubusercontent.com/1657336/207741868-60fc5fa8-fcf6-4510-aef9-bba6457fd1a4.png"> |




