### PR TITLE
Don't use the site name, use tagline in hero.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -29,10 +29,9 @@
 <div class="wp-block-column is-vertically-aligned-bottom wporg-hero-details" style="flex-basis:40%"><!-- wp:group {"align":"full","layout":{"type":"flex","orientation":"vertical","justifyContent":"right"}} -->
 <div class="wp-block-group alignfull"><!-- wp:group {"layout":{"type":"default"}} -->
 <div class="wp-block-group"><!-- wp:heading {"textColor":"white","className":"is-style-serif","fontSize":"extra-large"} -->
-<h2 class="is-style-serif has-white-color has-text-color has-extra-large-font-size"><?php esc_attr_e( 'Featuring:', 'wporg' ); ?></h2>
+<h2 class="is-style-serif has-white-color has-text-color has-extra-large-font-size"><?php esc_attr_e( 'Best-in-class Sites on WordPress', 'wporg' ); ?></h2>
 <!-- /wp:heading -->
-
-<!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontStyle":"italic","fontWeight":"400"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"textColor":"white","fontSize":"extra-large","fontFamily":"eb-garamond"} /--></div>
+</div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -160,6 +160,10 @@
 }
 
 @media (min-width: 782px) {
+	.wporg-hero-details {
+		margin-bottom: -4px !important; // Aligns the bottom with the image.
+	}
+
 	.wporg-hero-details > * {
 		text-align: left;
 	}

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -163,7 +163,9 @@
 	.wporg-hero-details {
 		margin-bottom: -4px !important; // Aligns the bottom with the image.
 	}
+}
 
+@media (min-width: 850px) {
 	.wporg-hero-details > * {
 		text-align: left;
 	}


### PR DESCRIPTION
Fixes: #113 

This PR changes the hero from "Featuring: {site}" to the tagline "Best-in-class Sites on WordPress".

**Note: This pr is waiting on copy confirmation in the associated ticket.**

| Before | After | 
| --- | --- |
| ![wordpress org_showcase_](https://user-images.githubusercontent.com/1657336/209256426-0d036a8f-9e9b-4494-9c7e-bf37d905b85f.png) | ![localhost_8888_](https://user-images.githubusercontent.com/1657336/209256435-390dd386-e5ee-4c6a-a6db-617057f30cfc.png) |



