### PR TITLE
Restrict font size on grid items on mobile.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -47,6 +47,16 @@
 }
 
 /*
+ * core/post-title.
+ */
+
+@media (max-width: 600px) {
+	.wp-block-post .wp-block-post-title {
+		font-size: 16px !important;
+	}
+}
+
+/*
  * Related Posts Styles
  */
 

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -50,7 +50,7 @@
  * core/post-title.
  */
 
-@media (max-width: 600px) {
+@media (max-width: 599px) {
 	.wp-block-post .wp-block-post-title {
 		font-size: 16px !important;
 	}


### PR DESCRIPTION
Fixes #114 

This PR updates the post-title to be`16px` on mobile.

**Considerations**
- The theme currently uses `em` units for `h*` margins. On mobile, the space between the top of the heading and the image could be considered tight. Leaving for now unless otherwise advised to implement a standard margin.
- `!important` is needed because theme.json styles also have that declaration.

### Homepage
| Before | After |
| --- | --- |
|  ![localhost_8888_(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/1657336/210193908-f5a361cb-0d03-4159-a473-ca33621a16af.png) | ![localhost_8888_(iPhone 12 Pro)](https://user-images.githubusercontent.com/1657336/210193915-4dbe7135-d29a-4e0f-ae80-d3ca88fed32f.png) | 



### Search Results
| Before | After |
| --- | --- |
|  ![localhost_8888__s=c(iPhone 12 Pro) (1)](https://user-images.githubusercontent.com/1657336/210193909-a9d024da-5f1d-40a3-9c1c-2658100b5bce.png) |  ![localhost_8888__s=c(iPhone 12 Pro)](https://user-images.githubusercontent.com/1657336/210193911-c0524e8d-3811-4adb-9c21-4474cd1b4956.png) | 
