### PR TITLE
Add support for two screenshots per site

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -57,6 +57,7 @@ function setup_theme() {
 	add_image_size( 'screenshot-desktop', 1400, 740, array( 'center', 'top' ) );
 	add_image_size( 'screenshot-mobile', 340, 600, array( 'center', 'top' ) );
 
+	// Add these sizes to the size dropdown in core image blocks.
 	add_filter(
 		'image_size_names_choose',
 		function( $sizes ) {

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -116,22 +116,27 @@ function get_site_domain( $post, $rem_trail_slash = false ) {
  * @return string
  */
 function site_screenshot_src( $post, $width = 1440, $height = 810 ) {
-	$screenshot = get_post_meta( $post->ID, 'screenshot', true );
+	$screenshot_url = get_post_meta( $post->ID, 'screenshot', true );
 	$cache_key = '20221208'; // To break out of cached image.
 
-	if ( empty( $screenshot ) ) {
-		$screenshot = 'https://wordpress.com/mshots/v1/http%3A%2F%2F' . urlencode( get_site_domain( $post ) . '?v=' . $cache_key );
-		$screenshot = add_query_arg( 'vpw', $width, $screenshot );
-		$screenshot = add_query_arg( 'vph', $height, $screenshot );
+	if ( empty( $screenshot_url ) ) {
+		$requested_url = 'https://' . get_site_domain( $post ) . '?v=' . $cache_key;
+		$screenshot_url = add_query_arg(
+			array(
+				'scale' => 2,
+				'vpw' => $width,
+				'vph' => $height,
+			),
+			'https://wordpress.com/mshots/v1/' . urlencode( $requested_url ),
+		);
 	} elseif ( function_exists( 'jetpack_photon_url' ) ) {
 		// Use Jetpack cache for non mShot images
-		$screenshot = jetpack_photon_url( $screenshot );
+		$screenshot_url = jetpack_photon_url( $screenshot_url );
 	}
 
-	$screenshot = apply_filters( 'wporg_showcase_screenshot_src', $screenshot, $post );
+	$screenshot_url = apply_filters( 'wporg_showcase_screenshot_src', $screenshot_url, $post );
 
-	// force screenshot URLs to be https
-	return str_replace( 'http://', 'https://', $screenshot );
+	return set_url_scheme( $screenshot_url, 'https' );
 }
 
 /**

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -10,10 +10,11 @@ require_once __DIR__ . '/src/site-screenshot/index.php';
 require_once __DIR__ . '/inc/shortcodes.php';
 
 // Filters and Actions
-add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_search_query' );
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_action( 'init', __NAMESPACE__ . '\setup_theme' );
 add_action( 'wp', __NAMESPACE__ . '\jetpack_remove_rp', 20 );
 add_action( 'wp_head', __NAMESPACE__ . '\add_social_meta_tags' );
+add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_search_query' );
 add_action( 'template_redirect', __NAMESPACE__ . '\redirect_urls' );
 add_filter( 'jetpack_images_get_images', __NAMESPACE__ . '\jetpack_fallback_image', 10, 3 );
 add_filter( 'jetpack_relatedposts_filter_thumbnail_size', __NAMESPACE__ . '\jetpack_change_image_size' );
@@ -43,7 +44,49 @@ function enqueue_assets() {
 		filemtime( __DIR__ . '/build/style/style-index.css' )
 	);
 	wp_style_add_data( 'wporg-showcase-2022-style', 'rtl', 'replace' );
+}
 
+/**
+ * Register theme support.
+ */
+function setup_theme() {
+	// Add the two image sizes (700 x 370, 170 x 300) at double for high-dpi screens.
+	// These images should be captured at 480 x 847 (mobile) and 1440 x 761 (desktop).
+	add_image_size( 'screenshot-desktop', 1400, 740, array( 'center', 'top' ) );
+	add_image_size( 'screenshot-mobile', 340, 600, array( 'center', 'top' ) );
+
+	add_filter(
+		'image_size_names_choose',
+		function( $sizes ) {
+			return array_merge(
+				$sizes,
+				array(
+					'screenshot-desktop' => __( 'Screenshot (Large)', 'wporg' ),
+					'screenshot-mobile' => __( 'Screenshot (Small)', 'wporg' ),
+				)
+			);
+		}
+	);
+
+	register_post_meta(
+		'post',
+		'screenshot-desktop',
+		array(
+			'show_in_rest' => true,
+			'single' => true,
+			'type' => 'integer',
+		)
+	);
+
+	register_post_meta(
+		'post',
+		'screenshot-mobile',
+		array(
+			'show_in_rest' => true,
+			'single' => true,
+			'type' => 'integer',
+		)
+	);
 }
 
 /**

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -2,6 +2,8 @@
 
 namespace WordPressdotorg\Theme\Showcase_2022;
 
+use function WordPressdotorg\Theme\Showcase_2022\Site_Screenshot\get_site_screenshot_src;
+
 // Block files
 require_once __DIR__ . '/src/link-group/index.php';
 require_once __DIR__ . '/src/site-edit-link/index.php';
@@ -110,36 +112,6 @@ function get_site_domain( $post, $rem_trail_slash = false ) {
 }
 
 /**
- * Returns url of site screenshot image.
- *
- * @param WP_Post $post
- * @return string
- */
-function site_screenshot_src( $post, $width = 1440, $height = 810 ) {
-	$screenshot_url = get_post_meta( $post->ID, 'screenshot', true );
-	$cache_key = '20221208'; // To break out of cached image.
-
-	if ( empty( $screenshot_url ) ) {
-		$requested_url = 'https://' . get_site_domain( $post ) . '?v=' . $cache_key;
-		$screenshot_url = add_query_arg(
-			array(
-				'scale' => 2,
-				'vpw' => $width,
-				'vph' => $height,
-			),
-			'https://wordpress.com/mshots/v1/' . urlencode( $requested_url ),
-		);
-	} elseif ( function_exists( 'jetpack_photon_url' ) ) {
-		// Use Jetpack cache for non mShot images
-		$screenshot_url = jetpack_photon_url( $screenshot_url );
-	}
-
-	$screenshot_url = apply_filters( 'wporg_showcase_screenshot_src', $screenshot_url, $post );
-
-	return set_url_scheme( $screenshot_url, 'https' );
-}
-
-/**
  * Provide mShot images to Jetpack related posts.
  */
 function jetpack_fallback_image( $media, $post_id, $args ) {
@@ -148,7 +120,7 @@ function jetpack_fallback_image( $media, $post_id, $args ) {
 	} else {
 		$post = get_post( $post_id );
 		$permalink = get_permalink( $post_id );
-		$url = site_screenshot_src( $post );
+		$url = get_site_screenshot_src( $post );
 
 		return array(
 			array(
@@ -387,7 +359,7 @@ function add_social_meta_tags() {
 	} elseif ( is_single() ) {
 		$og_fields['og:description'] = strip_tags( get_the_excerpt() );
 		$og_fields['og:url']         = esc_url( get_permalink() );
-		$og_fields['og:image']       = esc_url( site_screenshot_src( get_post() ) );
+		$og_fields['og:image']       = esc_url( get_site_screenshot_src( get_post() ) );
 	}
 
 	printf( '<meta name="twitter:card" content="summary_large_image">' . "\n" );

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/screenshot-auditor.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/screenshot-auditor.php
@@ -29,7 +29,7 @@
 	</p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:query {"queryId":1,"query":{"perPage":"100","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"full"} -->
+	<!-- wp:query {"queryId":1,"query":{"perPage":"3","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"full"} -->
 	<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|10","top":"var:preset|spacing|20"}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
@@ -39,20 +39,20 @@
 	<!-- /wp:group -->
 
 	<!-- wp:columns {"align":"full"} -->
-	<div class="wp-block-columns alignfull"><!-- wp:column {"width":"33.33%"} -->
-	<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:heading {"level":3,"fontSize":"small"} -->
-	<h3 class="has-small-font-size">Thumbnail</h3>
+	<div class="wp-block-columns alignfull"><!-- wp:column {"width":"75%"} -->
+	<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"small"} -->
+	<h3 class="has-small-font-size"><?php esc_attr_e( 'Desktop', 'wporg' ); ?></h3>
 	<!-- /wp:heading -->
 
-	<!-- wp:wporg/site-screenshot {"isLink":true} /--></div>
+	<!-- wp:wporg/site-screenshot {"isLink":true,"type":"desktop"} /--></div>
 	<!-- /wp:column -->
 
-	<!-- wp:column {"width":"66.66%"} -->
-	<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:heading {"level":3,"fontSize":"small"} -->
-	<h3 class="has-small-font-size">Large</h3>
+	<!-- wp:column {"width":"25%"} -->
+	<div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"fontSize":"small"} -->
+	<h3 class="has-small-font-size"><?php esc_attr_e( 'Mobile', 'wporg' ); ?></h3>
 	<!-- /wp:heading -->
 
-	<!-- wp:wporg/site-screenshot {"isLink":true,"useHiRes":true} /--></div>
+	<!-- wp:wporg/site-screenshot {"isLink":true,"type":"mobile"} /--></div>
 	<!-- /wp:column --></div>
 	<!-- /wp:columns --></div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/screenshot-auditor.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/screenshot-auditor.php
@@ -6,66 +6,62 @@
  */
 
 ?>
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--70)">
 
-<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
-<main class="wp-block-group entry-content">
-	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"default"}} -->
-	<div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--70)">
+<!-- wp:post-title {"level":1} /-->
 
-	<!-- wp:post-title {"level":1} /-->
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'This page displays the current screenshots for each site. These could be a manual upload (displayed with blue border) or a generated mShot.', 'wporg' ); ?></p>
+<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph -->
-	<p><?php esc_html_e( 'This page displays the current screenshots for each site. These could be a manual upload (displayed with blue border) or a generated mShot.', 'wporg' ); ?></p>
-	<!-- /wp:paragraph -->
+<!-- wp:paragraph -->
+<p>
+	<?php
+	printf(
+		/* translators: %s is the url for the screenshot manual upload instructions. */
+		wp_kses_post( __( 'If you see issues with one of the generated mShots (for example cookie notices or modals), click \'Edit site\' and upload a manual screenshot following <a href="%s" target="_blank" rel="noreferrer noopener">these instructions</a>.', 'wporg' ) ),
+		esc_url( 'https://github.com/WordPress/wporg-showcase-2022/wiki/Creating-a-Showcase-site-screenshot' )
+	); ?>
+</p>
+<!-- /wp:paragraph -->
 
-	<!-- wp:paragraph -->
-	<p>
-		<?php
-		printf(
-			/* translators: %s is the url for the screenshot manual upload instructions. */
-			wp_kses_post( __( 'If you see issues with one of the generated mShots (for example cookie notices or modals), click \'Edit site\' and upload a manual screenshot following <a href="%s" target="_blank" rel="noreferrer noopener">these instructions</a>.', 'wporg' ) ),
-			esc_url( 'https://github.com/WordPress/wporg-showcase-2022/wiki/Creating-a-Showcase-site-screenshot' )
-		); ?>
-	</p>
-	<!-- /wp:paragraph -->
+<!-- wp:query {"queryId":1,"query":{"perPage":"10","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"full"} -->
+<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|10","top":"var:preset|spacing|20"}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10)"><!-- wp:post-title {"fontSize":"extra-large"} /-->
 
-	<!-- wp:query {"queryId":1,"query":{"perPage":"3","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"full"} -->
-	<div class="wp-block-query alignfull"><!-- wp:post-template {"align":"full"} -->
-	<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|10","top":"var:preset|spacing|20"}},"border":{"top":{"color":"var:preset|color|light-grey-1","style":"solid"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignfull" style="border-top-color:var(--wp--preset--color--light-grey-1);border-top-style:solid;padding-top:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10)"><!-- wp:post-title {"fontSize":"extra-large"} /-->
+<!-- wp:wporg/site-edit-link {"style":{"typography":{"textDecoration":"underline"}}} /--></div>
+<!-- /wp:group -->
 
-	<!-- wp:wporg/site-edit-link {"style":{"typography":{"textDecoration":"underline"}}} /--></div>
-	<!-- /wp:group -->
+<!-- wp:columns {"align":"full"} -->
+<div class="wp-block-columns alignfull"><!-- wp:column {"width":"75%"} -->
+<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"small"} -->
+<h3 class="has-small-font-size"><?php esc_attr_e( 'Desktop', 'wporg' ); ?></h3>
+<!-- /wp:heading -->
 
-	<!-- wp:columns {"align":"full"} -->
-	<div class="wp-block-columns alignfull"><!-- wp:column {"width":"75%"} -->
-	<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"small"} -->
-	<h3 class="has-small-font-size"><?php esc_attr_e( 'Desktop', 'wporg' ); ?></h3>
-	<!-- /wp:heading -->
+<!-- wp:wporg/site-screenshot {"isLink":true,"type":"desktop"} /--></div>
+<!-- /wp:column -->
 
-	<!-- wp:wporg/site-screenshot {"isLink":true,"type":"desktop"} /--></div>
-	<!-- /wp:column -->
+<!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"fontSize":"small"} -->
+<h3 class="has-small-font-size"><?php esc_attr_e( 'Mobile', 'wporg' ); ?></h3>
+<!-- /wp:heading -->
 
-	<!-- wp:column {"width":"25%"} -->
-	<div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"fontSize":"small"} -->
-	<h3 class="has-small-font-size"><?php esc_attr_e( 'Mobile', 'wporg' ); ?></h3>
-	<!-- /wp:heading -->
+<!-- wp:wporg/site-screenshot {"isLink":true,"type":"mobile"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+<!-- /wp:post-template -->
 
-	<!-- wp:wporg/site-screenshot {"isLink":true,"type":"mobile"} /--></div>
-	<!-- /wp:column --></div>
-	<!-- /wp:columns --></div>
-	<!-- /wp:group -->
-	<!-- /wp:post-template -->
+<!-- wp:query-pagination -->
+<!-- wp:query-pagination-previous /-->
 
-	<!-- wp:query-pagination -->
-	<!-- wp:query-pagination-previous /-->
+<!-- wp:query-pagination-numbers /-->
 
-	<!-- wp:query-pagination-numbers /-->
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination --></div>
+<!-- /wp:query -->
 
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination --></div>
-	<!-- /wp:query -->
-
-	</div><!-- /wp:group -->
-</main><!-- /wp:group -->
+</div><!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
@@ -52,5 +52,6 @@
 	},
 	"usesContext": [ "postId" ],
 	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css"
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
@@ -17,9 +17,10 @@
 			"type": "boolean",
 			"default": false
 		},
-		"size": {
+		"type": {
 			"type": "string",
-			"default": "screenshot-desktop"
+			"default": "desktop",
+			"enum": [ "desktop", "mobile" ]
 		}
 	},
 	"supports": {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
@@ -13,13 +13,13 @@
 			"type": "boolean",
 			"default": false
 		},
-		"useHiRes": {
-			"type": "boolean",
-			"default": false
-		},
 		"lazyLoad": {
 			"type": "boolean",
 			"default": false
+		},
+		"size": {
+			"type": "string",
+			"default": "screenshot-desktop"
 		}
 	},
 	"supports": {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/plugin.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/plugin.js
@@ -26,10 +26,10 @@ const ScreenshotPanel = () => {
 
 	return (
 		<PluginDocumentSettingPanel name="wporg-screenshots" title={ __( 'Screenshots', 'wporg' ) }>
-			<ScreenshotUpload metaKey="screenshot-desktop" label="Desktop" />
+			<ScreenshotUpload metaKey="screenshot-desktop" label={ __( 'Desktop', 'wporg' ) } />
 			<p>{ __( 'Capture a desktop image at 1440 wide by 761 tall.', 'wporg' ) }</p>
 			<hr />
-			<ScreenshotUpload metaKey="screenshot-mobile" label="Mobile" />
+			<ScreenshotUpload metaKey="screenshot-mobile" label={ __( 'Mobile', 'wporg' ) } />
 			<p>{ __( 'Capture a mobile image at 480 wide by 847 tall.', 'wporg' ) }</p>
 		</PluginDocumentSettingPanel>
 	);

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/plugin.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/plugin.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { store as editorStore } from '@wordpress/editor';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { registerPlugin } from '@wordpress/plugins';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import ScreenshotUpload from './upload-button';
+import '../editor.scss';
+
+const SITE_POST_TYPE = 'post';
+
+const ScreenshotPanel = () => {
+	const postType = useSelect( ( select ) => {
+		return select( editorStore ).getEditedPostAttribute( 'type' );
+	}, [] );
+
+	if ( postType !== SITE_POST_TYPE ) {
+		return null;
+	}
+
+	return (
+		<PluginDocumentSettingPanel name="wporg-screenshots" title={ __( 'Screenshots', 'wporg' ) }>
+			<ScreenshotUpload metaKey="screenshot-desktop" label="Desktop" />
+			<p>{ __( 'Capture a desktop image at 1440 wide by 761 tall.', 'wporg' ) }</p>
+			<hr />
+			<ScreenshotUpload metaKey="screenshot-mobile" label="Mobile" />
+			<p>{ __( 'Capture a mobile image at 480 wide by 847 tall.', 'wporg' ) }</p>
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'wporg-screenshots-panel', {
+	render: ScreenshotPanel,
+} );

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/upload-button.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/upload-button.js
@@ -1,0 +1,164 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, DropZone, ResponsiveWrapper, Spinner, withNotices } from '@wordpress/components';
+import { isBlobURL } from '@wordpress/blob';
+import { useRef, useState } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { MediaUpload, MediaUploadCheck, store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+
+const instructions = <p>{ __( 'To edit the featured image, you need permission to upload media.', 'wporg' ) }</p>;
+
+function getMediaDetails( media, size = 'screenshot-desktop' ) {
+	if ( ! media ) {
+		return {};
+	}
+
+	if ( size in ( media?.media_details?.sizes ?? {} ) ) {
+		return {
+			mediaWidth: media.media_details.sizes[ size ].width,
+			mediaHeight: media.media_details.sizes[ size ].height,
+			mediaSourceUrl: media.media_details.sizes[ size ].source_url,
+		};
+	}
+
+	// Use full image size when fallbackSize and defaultSize are not available.
+	return {
+		mediaWidth: media.media_details.width,
+		mediaHeight: media.media_details.height,
+		mediaSourceUrl: media.source_url,
+	};
+}
+
+function ScreenshotUpload( { metaKey, label, noticeUI, noticeOperations } ) {
+	const { meta, media, mediaId, mediaUpload } = useSelect( ( select ) => {
+		const _meta = select( editorStore ).getEditedPostAttribute( 'meta' );
+		const _mediaId = _meta[ metaKey ];
+		const _media = _mediaId ? select( coreStore ).getMedia( _mediaId, { context: 'view' } ) : null;
+
+		return {
+			meta: _meta,
+			mediaId: _mediaId,
+			media: _media,
+			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
+		};
+	}, [] );
+	const { editPost } = useDispatch( editorStore );
+	const toggleRef = useRef();
+	const [ isLoading, setIsLoading ] = useState( false );
+	const { mediaWidth, mediaHeight, mediaSourceUrl } = getMediaDetails( media, metaKey );
+
+	const onUpdateImage = ( image ) => {
+		editPost( { meta: { ...meta, [ metaKey ]: image.id } } );
+	};
+
+	const onRemoveImage = () => {
+		editPost( { meta: { ...meta, [ metaKey ]: 0 } } );
+	};
+	const onDropFiles = ( filesList ) => {
+		mediaUpload( {
+			allowedTypes: [ 'image' ],
+			filesList: filesList,
+			onFileChange: ( [ image ] ) => {
+				if ( isBlobURL( image?.url ) ) {
+					setIsLoading( true );
+					return;
+				}
+				onUpdateImage( image );
+				setIsLoading( false );
+			},
+			onError: ( message ) => {
+				noticeOperations.removeAllNotices();
+				noticeOperations.createErrorNotice( message );
+			},
+		} );
+	};
+
+	return (
+		<>
+			{ noticeUI }
+			<div className="wporg-site-screenshot">
+				{ media && (
+					<div id={ `wporg-site-screenshot-${ mediaId }-describedby` } className="hidden">
+						{ media.alt_text &&
+							sprintf(
+								// Translators: %s: The selected image alt text.
+								__( 'Current image: %s', 'wporg' ),
+								media.alt_text
+							) }
+						{ ! media.alt_text &&
+							sprintf(
+								// Translators: %s: The selected image filename.
+								__( 'The current image has no alternative text. The file name is: %s', 'wporg' ),
+								media.media_details.sizes?.full?.file || media.slug
+							) }
+					</div>
+				) }
+				<MediaUploadCheck fallback={ instructions }>
+					<MediaUpload
+						onSelect={ onUpdateImage }
+						unstableFeaturedImageFlow
+						allowedTypes={ [ 'image' ] }
+						render={ ( { open } ) => (
+							<div className="wporg-site-screenshot__container">
+								<Button
+									ref={ toggleRef }
+									className={
+										! mediaId
+											? 'wporg-site-screenshot__toggle'
+											: 'wporg-site-screenshot__preview'
+									}
+									onClick={ open }
+									aria-label={ ! mediaId ? null : __( 'Edit or replace the image', 'wporg' ) }
+									aria-describedby={
+										! mediaId ? null : `wporg-site-screenshot-${ mediaId }-describedby`
+									}
+								>
+									{ !! mediaId && media && (
+										<ResponsiveWrapper
+											naturalWidth={ mediaWidth }
+											naturalHeight={ mediaHeight }
+											isInline
+										>
+											<img src={ mediaSourceUrl } alt="" />
+										</ResponsiveWrapper>
+									) }
+									{ isLoading && <Spinner /> }
+									{ ! mediaId && ! isLoading && label }
+								</Button>
+								{ !! mediaId && (
+									<div className="wporg-site-screenshot__actions">
+										<Button
+											className="wporg-site-screenshot__action"
+											onClick={ open }
+											aria-hidden="true"
+										>
+											{ __( 'Replace', 'wporg' ) }
+										</Button>
+										<Button
+											className="wporg-site-screenshot__action"
+											onClick={ () => {
+												onRemoveImage();
+												toggleRef.current.focus();
+											} }
+										>
+											{ __( 'Remove', 'wporg' ) }
+										</Button>
+									</div>
+								) }
+								<DropZone onFilesDrop={ onDropFiles } />
+							</div>
+						) }
+						value={ mediaId }
+					/>
+				</MediaUploadCheck>
+			</div>
+		</>
+	);
+}
+
+export default compose( withNotices )( ScreenshotUpload );

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/editor.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/editor.scss
@@ -1,0 +1,78 @@
+.wporg-site-screenshot {
+	padding: 0;
+
+	.components-spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
+	}
+
+	.components-responsive-wrapper__content {
+		max-width: 100%;
+		width: auto;
+		max-height: 200px;
+	}
+}
+
+.wporg-site-screenshot__container {
+	position: relative;
+}
+
+.wporg-site-screenshot__toggle,
+.wporg-site-screenshot__preview {
+	width: 100%;
+	padding: 0;
+	box-shadow: 0 0 0 0 var(--wp-admin-theme-color);
+	overflow: hidden; // Ensure the focus style properly encapsulates the image.
+}
+
+.wporg-site-screenshot__preview {
+	height: auto;
+
+	.components-responsive-wrapper {
+		width: 100%;
+		background: #f0f0f0;
+		min-height: 90px;
+	}
+}
+
+.wporg-site-screenshot__toggle {
+	padding: 8px 0;
+	min-height: 90px;
+	display: flex;
+	border-radius: 2px;
+	background-color: #f0f0f0;
+	line-height: 20px;
+	text-align: center;
+	justify-content: center;
+
+	&:hover {
+		background: #ddd;
+		color: #1e1e1e;
+	}
+}
+
+.wporg-site-screenshot__actions {
+	position: absolute;
+	bottom: 0;
+	padding: 8px;
+	width: 100%;
+	display: flex;
+	gap: 8px;
+	opacity: 0; // Use opacity instead of visibility so that the buttons remain in the tab order.
+
+	.wporg-site-screenshot__container:hover &,
+	.wporg-site-screenshot__container:focus &,
+	.wporg-site-screenshot__container:focus-within & {
+		opacity: 1;
+	}
+}
+
+.wporg-site-screenshot__action {
+	backdrop-filter: blur(16px) saturate(180%);
+	background: rgba(255, 255, 255, 0.75);
+	flex-grow: 1;
+	justify-content: center;
+}

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -2,11 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, Placeholder, SelectControl, ToggleControl } from '@wordpress/components';
 import { image } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -15,16 +14,7 @@ import metadata from './block.json';
 import './components/plugin';
 import './style.scss';
 
-function Edit( { attributes: { isLink, lazyLoad, size }, setAttributes, clientId } ) {
-	const sizeOptions = useSelect(
-		( select ) => {
-			const settings = select( blockEditorStore ).getSettings();
-
-			return settings.imageSizes.map( ( { slug, name } ) => ( { label: name, value: slug } ) );
-		},
-		[ clientId ]
-	);
-
+function Edit( { attributes: { isLink, lazyLoad, type }, setAttributes } ) {
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
@@ -40,9 +30,12 @@ function Edit( { attributes: { isLink, lazyLoad, size }, setAttributes, clientId
 						onChange={ () => setAttributes( { lazyLoad: ! lazyLoad } ) }
 					/>
 					<SelectControl
-						label={ __( 'Image size', 'wporg' ) }
-						value={ size }
-						options={ sizeOptions }
+						label={ __( 'Image', 'wporg' ) }
+						value={ type }
+						options={ [
+							{ label: __( 'Desktop', 'wporg' ), value: 'desktop' },
+							{ label: __( 'Mobile', 'wporg' ), value: 'mobile' },
+						] }
 						onChange={ ( newValue ) => setAttributes( { size: newValue } ) }
 					/>
 				</PanelBody>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { image } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, Placeholder, ToggleControl } from '@wordpress/components';
+import { InspectorControls, store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, Placeholder, SelectControl, ToggleControl } from '@wordpress/components';
+import { image } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,7 +15,16 @@ import metadata from './block.json';
 import './components/plugin';
 import './style.scss';
 
-function Edit( { attributes: { isLink, useHiRes, lazyLoad }, setAttributes } ) {
+function Edit( { attributes: { isLink, lazyLoad, size }, setAttributes, clientId } ) {
+	const sizeOptions = useSelect(
+		( select ) => {
+			const settings = select( blockEditorStore ).getSettings();
+
+			return settings.imageSizes.map( ( { slug, name } ) => ( { label: name, value: slug } ) );
+		},
+		[ clientId ]
+	);
+
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
@@ -25,14 +35,15 @@ function Edit( { attributes: { isLink, useHiRes, lazyLoad }, setAttributes } ) {
 						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 					/>
 					<ToggleControl
-						label={ __( 'Use high resolution image', 'wporg' ) }
-						checked={ useHiRes }
-						onChange={ () => setAttributes( { useHiRes: ! useHiRes } ) }
-					/>
-					<ToggleControl
 						label={ __( 'Lazy load image', 'wporg' ) }
 						checked={ lazyLoad }
 						onChange={ () => setAttributes( { lazyLoad: ! lazyLoad } ) }
+					/>
+					<SelectControl
+						label={ __( 'Image size', 'wporg' ) }
+						value={ size }
+						options={ sizeOptions }
+						onChange={ ( newValue ) => setAttributes( { size: newValue } ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.js
@@ -11,6 +11,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import metadata from './block.json';
+import './components/plugin';
 import './style.scss';
 
 function Edit( { attributes: { isLink, useHiRes, lazyLoad }, setAttributes } ) {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -47,10 +47,6 @@ function render( $attributes, $content, $block ) {
 
 	$screenshot = site_screenshot_src( $post );
 
-	if ( isset( $attributes['useHiRes'] ) && true === $attributes['useHiRes'] ) {
-		$screenshot = add_query_arg( 'scale', 2, $screenshot );
-	}
-
 	$loading = 'eager';
 	if ( isset( $attributes['lazyLoad'] ) && true === $attributes['lazyLoad'] ) {
 		$loading = 'lazy';

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
@@ -19,6 +19,5 @@
 	img {
 		width: 100%;
 		vertical-align: middle;
-		aspect-ratio: 16 / 9;
 	}
 }

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page-screenshot-auditor.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page-screenshot-auditor.html
@@ -1,5 +1,9 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:pattern {"slug":"wporg-showcase-2022/screenshot-auditor"} /-->
+<!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"top":"var:preset|spacing|40","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space","bottom":"var:preset|spacing|40"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
+<main class="wp-block-group entry-content" style="padding-top:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40)">
+	<!-- wp:pattern {"slug":"wporg-showcase-2022/screenshot-auditor"} /-->
+</main>
+<!-- /wp:group -->
 
 <!-- wp:wporg/global-footer /-->

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -8,7 +8,17 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)">
-	<!-- wp:wporg/site-screenshot {"align":"full","style":{"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
+	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"top":{},"right":{},"left":{}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-style:solid;border-bottom-width:1px;margin-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","verticalAlignment":"bottom"}} -->
+		<div class="wp-block-group">
+			<!-- wp:wporg/site-screenshot {"style":{"border":{"radius":{"topLeft":"20px","topRight":"20px"},"top":{"color":"#1a191908","style":"solid","width":"10px"},"right":{"color":"#1a191908","style":"solid","width":"10px"},"bottom":{},"left":{"color":"#1a191908","style":"solid","width":"10px"}}}} /-->
+	
+			<!-- wp:wporg/site-screenshot {"style":{"border":{"radius":{"topLeft":"20px","topRight":"20px"},"top":{"color":"#1a191908","style":"solid","width":"10px"},"right":{"color":"#1a191908","style":"solid","width":"10px"},"bottom":{},"left":{"color":"#1a191908","style":"solid","width":"10px"}}},"type":"mobile"} /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
 
 	<!-- wp:pattern {"slug":"wporg-showcase-2022/page-single"} /-->
 </main>

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -8,7 +8,7 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)">
-	<!-- wp:wporg/site-screenshot {"useHiRes":true,"align":"full","style":{"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
+	<!-- wp:wporg/site-screenshot {"align":"full","style":{"border":{"bottom":{"color":"var:preset|color|light-grey-1","width":"1px"}},"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} /-->
 
 	<!-- wp:pattern {"slug":"wporg-showcase-2022/page-single"} /-->
 </main>


### PR DESCRIPTION
The design currently has two screenshots in the single page header, a desktop and mobile screenshot. The archive grid templates also use a screenshot with the same aspect ratio as the desktop image. So we can use two images per site to achieve this look, one desktop & one mobile.

This PR updates the current screenshot preview block (generated using mshots) and adds new meta fields for custom uploads, along with a UI in the editor.

The expectation is that the screenshots will be resized to display at 700 × 370 & 170 × 300 on the single page, so those are the aspect ratios used for capturing from mshots. Specifically, we capture at a viewport of 1440px × 761px & 480px × 847px — those widths can be adjusted, but the height is generated from the display size.

I've switched the `wporg/site-screenshot` to use a `type` attribute instead of `useHiRes`, thinking that we might need to add additional types/sizes later.

| Editor | Single | Grid |
|---|---|---|
| ![editor](https://github.com/WordPress/wporg-showcase-2022/assets/541093/7354e532-230f-4051-a86c-eed6ebe3c33d) | ![showcase-header](https://github.com/WordPress/wporg-showcase-2022/assets/541093/fd4cc7bc-8f09-4216-8327-f281f19241e7) | ![Screen Shot 2023-07-05 at 14 13 25](https://github.com/WordPress/wporg-showcase-2022/assets/541093/f28013b5-c2bb-4ec9-b228-0545ce8c3359) |

If there's an issue uploading, a notice is displayed above the upload drop area.
<img width="280" alt="Screenshot 2023-07-05 at 1 56 00 PM" src="https://github.com/WordPress/wporg-showcase-2022/assets/541093/50a494e8-0d37-41b4-bf00-97489bf68633">

<details>
<summary>Audit page: long screenshot, can see both custom (blue borders) and generated images.</summary>

![screenshot-audits](https://github.com/WordPress/wporg-showcase-2022/assets/541093/6a3c7154-075f-4513-a731-9936ac142c61)

</details>

To test
1. Build the branch
2. Generated screenshots
    - View a site (maybe reload, so mshots can work)
    - The screenshots should be from `https://wordpress.com/mshots/v1/…`
    - There should be two screenshots, one visibly a desktop size and one mobile size
    - They should not be distorted on either the homepage grid or single pages
3. Custom screenshots
    - Edit a site, see the Screenshots panel in the document sidebar
    - Add some images
    - They should appear on the frontend of the site
    - They should not be distorted on either the homepage grid or single pages

No design review needed yet, the design is not final so all I've really done is dropped the blocks on the page.