### PR TITLE
Single sites: Add a feature color behind the screenshots

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -56,6 +56,9 @@ function setup_theme() {
 	add_image_size( 'screenshot-desktop', 2044, 1150, array( 'center', 'top' ) );
 	add_image_size( 'screenshot-mobile', 750, 1334, array( 'center', 'top' ) );
 
+	// Add tonesque support so that Jetpack loads the class.
+	add_theme_support( 'tonesque' );
+
 	// Add these sizes to the size dropdown in core image blocks.
 	add_filter(
 		'image_size_names_choose',

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -93,6 +93,16 @@ function setup_theme() {
 
 	register_post_meta(
 		'post',
+		'feature-color',
+		array(
+			'show_in_rest' => true,
+			'single' => true,
+			'type' => 'string',
+		)
+	);
+
+	register_post_meta(
+		'post',
 		'domain',
 		array(
 			'show_in_rest' => true,

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -52,10 +52,9 @@ function enqueue_assets() {
  * Register theme support.
  */
 function setup_theme() {
-	// Add the two image sizes (700 x 370, 170 x 300) at double for high-dpi screens.
-	// These images should be captured at 480 x 847 (mobile) and 1440 x 761 (desktop).
-	add_image_size( 'screenshot-desktop', 1400, 740, array( 'center', 'top' ) );
-	add_image_size( 'screenshot-mobile', 340, 600, array( 'center', 'top' ) );
+	// Add the two image sizes at double for high-dpi screens.
+	add_image_size( 'screenshot-desktop', 2044, 1150, array( 'center', 'top' ) );
+	add_image_size( 'screenshot-mobile', 750, 1334, array( 'center', 'top' ) );
 
 	// Add these sizes to the size dropdown in core image blocks.
 	add_filter(

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -7,24 +7,36 @@
 
 ?>
 
-<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"}}},"fontSize":"heading-2"} /-->
-<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"},"padding":{"bottom":"var:preset|spacing|10"}}},"className":"external-link"} -->
-<p class="external-link" style="margin-bottom:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10)"><a href="[domain]" target="_blank" rel="noopener noreferrer">[pretty_domain]</a></p>
-<!-- /wp:paragraph -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:columns {"align":"wide"} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column {"width":"66.66%"} -->
+		<div class="wp-block-column" style="flex-basis:66.66%">
+			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"}}},"fontSize":"heading-2"} /-->
 
-<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
+			<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"},"padding":{"bottom":"var:preset|spacing|10"}}},"className":"external-link"} -->
+			<p class="external-link" style="margin-bottom:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10)"><a href="[domain]" target="_blank" rel="noopener noreferrer">[pretty_domain]</a></p>
+			<!-- /wp:paragraph -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"},"margin":{"top":"var:preset|spacing|30"}},"border":{"radius":"2px"}},"backgroundColor":"blueberry-4"} -->
-<div class="wp-block-group has-blueberry-4-background-color has-background" style="border-radius:2px;margin-top:var(--wp--preset--spacing--30);padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"normal","fontFamily":"inter"} -->
-<h2 class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:600"><?php esc_attr_e( 'More about this site', 'wporg' ); ?></h2>
-<!-- /wp:heading -->
-<!-- wp:wporg/site-meta-list /--></div>
-<!-- /wp:group -->
+			<!-- wp:post-content /-->
+		</div>
+		<!-- /wp:column -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|40"}}}} -->
-<div id="wporg-related-posts" class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40)"><!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"normal","fontFamily":"inter"} -->
-<h2 class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:700"><?php esc_attr_e( 'Related sites', 'wporg' ); ?></h2>
-<!-- /wp:heading -->
+		<!-- wp:column {"width":"33.33%"} -->
+		<div class="wp-block-column" style="flex-basis:33.33%">
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}},"border":{"radius":"2px"}},"backgroundColor":"blueberry-4"} -->
+			<div class="wp-block-group has-blueberry-4-background-color has-background" style="border-radius:2px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
+				<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"normal","fontFamily":"inter"} -->
+				<h2 class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:600"><?php esc_attr_e( 'More about this site', 'wporg' ); ?></h2>
+				<!-- /wp:heading -->
 
-<!-- wp:jetpack/related-posts {"displayDate":false,"displayThumbnails":true} /--></div>
+				<!-- wp:wporg/site-meta-list /-->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/color-control.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/color-control.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { BaseControl, ColorIndicator, PanelRow, TextControl } from '@wordpress/components';
+import { Icon, warning } from '@wordpress/icons';
+import { store as editorStore } from '@wordpress/editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+function ColorControl( { label, description } ) {
+	const meta = useSelect( ( select ) => select( editorStore ).getEditedPostAttribute( 'meta' ), [] );
+	const { editPost } = useDispatch( editorStore );
+	const value = meta[ 'feature-color' ] || '#f6f6f6';
+	const onUpdate = ( newValue ) => {
+		const hexValue = newValue.startsWith( '#' ) ? newValue : '#' + newValue;
+		editPost( { meta: { ...meta, 'feature-color': hexValue } } );
+	};
+	const hexValue = value.replace( '#', '' );
+	const isValid = /^[0-9a-f]+$/.test( hexValue ) && [ 3, 4, 6, 8 ].includes( hexValue.length );
+
+	return (
+		<>
+			<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
+			<p>{ description }</p>
+			<PanelRow>
+				{ isValid ? <ColorIndicator colorValue={ value } /> : <Icon fill="#cc1818" icon={ warning } /> }
+				<TextControl label={ label } hideLabelFromVision value={ value } onChange={ onUpdate } />
+			</PanelRow>
+		</>
+	);
+}
+
+export default ColorControl;

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/color-control.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/color-control.js
@@ -1,31 +1,55 @@
 /**
  * WordPress dependencies
  */
-import { BaseControl, ColorIndicator, PanelRow, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { BaseControl, Button, ColorIndicator, PanelRow, TextControl, ToggleControl } from '@wordpress/components';
 import { Icon, warning } from '@wordpress/icons';
 import { store as editorStore } from '@wordpress/editor';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+
+const DEFAULT_COLOR = '#f6f6f6';
 
 function ColorControl( { label, description } ) {
+	const [ useImageColor, setUseImageColor ] = useState( true );
 	const meta = useSelect( ( select ) => select( editorStore ).getEditedPostAttribute( 'meta' ), [] );
 	const { editPost } = useDispatch( editorStore );
-	const value = meta[ 'feature-color' ] || '#f6f6f6';
+	const value = meta[ 'feature-color' ] || DEFAULT_COLOR;
 	const onUpdate = ( newValue ) => {
 		const hexValue = newValue.startsWith( '#' ) ? newValue : '#' + newValue;
 		editPost( { meta: { ...meta, 'feature-color': hexValue } } );
 	};
 	const hexValue = value.replace( '#', '' );
 	const isValid = /^[0-9a-f]+$/.test( hexValue ) && [ 3, 4, 6, 8 ].includes( hexValue.length );
+	const hasImage = !! meta[ 'screenshot-desktop' ];
 
 	return (
-		<>
+		<div className="wporg-site-color">
 			<BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel>
 			<p>{ description }</p>
-			<PanelRow>
-				{ isValid ? <ColorIndicator colorValue={ value } /> : <Icon fill="#cc1818" icon={ warning } /> }
-				<TextControl label={ label } hideLabelFromVision value={ value } onChange={ onUpdate } />
-			</PanelRow>
-		</>
+			{ hasImage && (
+				<ToggleControl
+					label={ __( 'Use color from image', 'wporg' ) }
+					checked={ useImageColor }
+					onChange={ () => {
+						const willUseImageColor = ! useImageColor;
+						onUpdate( willUseImageColor ? '' : DEFAULT_COLOR );
+						setUseImageColor( willUseImageColor );
+					} }
+				/>
+			) }
+			{ ( ! useImageColor || ! hasImage ) && (
+				<PanelRow>
+					{ isValid ? (
+						<ColorIndicator colorValue={ value } />
+					) : (
+						<Icon fill="#cc1818" icon={ warning } />
+					) }
+					<TextControl label={ label } hideLabelFromVision value={ value } onChange={ onUpdate } />
+					<Button onClick={ () => onUpdate( DEFAULT_COLOR ) }>{ __( 'Reset', 'wporg' ) }</Button>
+				</PanelRow>
+			) }
+		</div>
 	);
 }
 

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/color-control.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/color-control.js
@@ -6,7 +6,8 @@ import { BaseControl, Button, ColorIndicator, PanelRow, TextControl, ToggleContr
 import { Icon, warning } from '@wordpress/icons';
 import { store as editorStore } from '@wordpress/editor';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
+import { usePrevious } from '@wordpress/compose';
 
 const DEFAULT_COLOR = '#f6f6f6';
 
@@ -22,6 +23,23 @@ function ColorControl( { label, description } ) {
 	const hexValue = value.replace( '#', '' );
 	const isValid = /^[0-9a-f]+$/.test( hexValue ) && [ 3, 4, 6, 8 ].includes( hexValue.length );
 	const hasImage = !! meta[ 'screenshot-desktop' ];
+	const prevHasImage = usePrevious( hasImage );
+
+	useEffect( () => {
+		// No previous state, initial values OK.
+		if ( prevHasImage === undefined ) {
+			return;
+		}
+		if ( ! prevHasImage && hasImage ) {
+			// If an image was added, but we have a custom color, keep the toggle off.
+			if ( hexValue !== DEFAULT_COLOR.replace( '#', '' ) ) {
+				setUseImageColor( false );
+			} else {
+				// The color is the default, but clear it so the frontend works.
+				onUpdate( '' );
+			}
+		}
+	}, [ hasImage, hexValue ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<div className="wporg-site-color">

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/plugin.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/plugin.js
@@ -28,10 +28,10 @@ const ScreenshotPanel = () => {
 	return (
 		<PluginDocumentSettingPanel name="wporg-screenshots" title={ __( 'Screenshots', 'wporg' ) }>
 			<ScreenshotUpload metaKey="screenshot-desktop" label={ __( 'Desktop', 'wporg' ) } />
-			<p>{ __( 'Capture a desktop image at 1440 wide by 761 tall.', 'wporg' ) }</p>
+			<p>{ __( 'Capture a desktop image at 1920 wide by 1080 tall, use at least 2x dpi.', 'wporg' ) }</p>
 			<hr />
 			<ScreenshotUpload metaKey="screenshot-mobile" label={ __( 'Mobile', 'wporg' ) } />
-			<p>{ __( 'Capture a mobile image at 480 wide by 847 tall.', 'wporg' ) }</p>
+			<p>{ __( 'Capture a mobile image at 375 wide by 667 tall, use at least 2x dpi.', 'wporg' ) }</p>
 			<hr />
 			<ColorControl
 				label={ __( 'Color', 'wporg' ) }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/plugin.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/components/plugin.js
@@ -10,6 +10,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import ColorControl from './color-control';
 import ScreenshotUpload from './upload-button';
 import '../editor.scss';
 
@@ -31,6 +32,11 @@ const ScreenshotPanel = () => {
 			<hr />
 			<ScreenshotUpload metaKey="screenshot-mobile" label={ __( 'Mobile', 'wporg' ) } />
 			<p>{ __( 'Capture a mobile image at 480 wide by 847 tall.', 'wporg' ) }</p>
+			<hr />
+			<ColorControl
+				label={ __( 'Color', 'wporg' ) }
+				description={ __( 'Feature color to use as header background.', 'wporg' ) }
+			/>
 		</PluginDocumentSettingPanel>
 	);
 };

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/editor.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/editor.scss
@@ -76,3 +76,13 @@
 	flex-grow: 1;
 	justify-content: center;
 }
+
+.wporg-site-color {
+	.components-panel__row {
+		gap: 8px;
+	}
+
+	.component-color-indicator {
+		min-width: 20px;
+	}
+}

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -11,6 +11,7 @@ namespace WordPressdotorg\Theme\Showcase_2022\Site_Screenshot;
 use function WordPressdotorg\Theme\Showcase_2022\get_site_domain;
 
 add_action( 'init', __NAMESPACE__ . '\init' );
+add_filter( 'render_block_core/group', __NAMESPACE__ . '\inject_background_color', 10, 3 );
 
 /**
  * Registers the block using the metadata loaded from the `block.json` file.
@@ -119,4 +120,37 @@ function get_site_screenshot_src( $post, $type = 'desktop' ) {
 	$screenshot_url = apply_filters( 'wporg_showcase_screenshot_src', $screenshot_url, $post );
 
 	return is_ssl() ? set_url_scheme( $screenshot_url, 'https' ) : $screenshot_url;
+}
+
+/**
+ * Filter the group content and inject a background color if we find the background class.
+ *
+ * @param string   $block_content The block content.
+ * @param array    $block         The full block, including name and attributes.
+ * @param WP_Block $instance      The block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function inject_background_color( $block_content, $block, $instance ) {
+	$class = 'has-feature-color-background';
+	if ( ! isset( $block['attrs']['className'] ) || $block['attrs']['className'] !== $class ) {
+		return $block_content;
+	}
+	global $post;
+	$color = get_post_meta( $post->ID, 'feature-color', true );
+	if ( ! $color || '#' === $color ) {
+		return $block_content;
+	}
+
+	// Use the html tag processer to merge with any existing styles.
+	$html = new \WP_HTML_Tag_Processor( $block_content );
+	$html->next_tag();
+	$style = $html->get_attribute( 'style' );
+
+	// Remove existing background if there is one.
+	$style = preg_replace( '/background-color:[^;]+;/', '', $style );
+	$style .= ';background-color:' . esc_attr( $color );
+	$html->set_attribute( 'style', $style );
+
+	return $html->get_updated_html();
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/index.php
@@ -60,10 +60,10 @@ function render( $attributes, $content, $block ) {
 		esc_attr( $loading )
 	);
 
-	$classname = '';
+	$classname = 'is-size-' . esc_attr( $attributes['type'] );
 	if ( isset( $attributes['isLink'] ) && true == $attributes['isLink'] ) {
 		$img_content = '<a href="' . get_permalink( $post ) . '">' . $img_content . '</a>';
-		$classname = 'is-linked-image';
+		$classname .= ' is-linked-image';
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classname ) );
@@ -98,17 +98,15 @@ function get_site_screenshot_src( $post, $type = 'desktop' ) {
 
 	if ( ! $screenshot_url ) {
 		$requested_url = 'https://' . get_site_domain( $post ) . '?v=' . $cache_key;
-		$viewport_width = $all_sizes[ $size ]['width'];
-		$viewport_height = $all_sizes[ $size ]['height'];
-		$ratio = $viewport_height / $viewport_width;
+		$image_width = $all_sizes[ $size ]['width'];
+		$image_height = $all_sizes[ $size ]['height'];
 
 		$screenshot_url = add_query_arg(
 			array(
 				'scale' => 2,
-				'w' => 'mobile' === $type ? 480 : 1440,
-				'h' => 'mobile' === $type ? 480 * $ratio : 1440 * $ratio,
-				'vpw' => $viewport_width,
-				'vph' => $viewport_height,
+				'w' => $image_width,
+				'vpw' => 'mobile' === $type ? 375 : 1920,
+				'vph' => 'mobile' === $type ? 667 : 1080,
 			),
 			'https://wordpress.com/mshots/v1/' . urlencode( $requested_url ),
 		);

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
@@ -15,6 +15,11 @@
 		outline-offset: -1.5px;
 	}
 
+	.has-feature-color-background & {
+		border-radius: 20px 20px 0 0;
+		border-bottom-width: 0;
+	}
+
 	a {
 		display: block;
 

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
@@ -18,6 +18,11 @@
 	.has-feature-color-background & {
 		border-radius: 20px 20px 0 0;
 		border-bottom-width: 0;
+		flex: 1;
+
+		&:first-child {
+			flex: 4;
+		}
 	}
 
 	a {

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -8,8 +8,8 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)">
-	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|40"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"}},"color":{"background":"#f6f6f6"}},"className":"has-feature-color-background","layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignfull has-feature-color-background has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-style:solid;border-bottom-width:1px;background-color:#f6f6f6;margin-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--40)">
+	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"}},"color":{"background":"#f6f6f6"}},"className":"has-feature-color-background","layout":{"type":"constrained","wideSize":"1760px"}} -->
+	<div class="wp-block-group alignfull has-feature-color-background has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-style:solid;border-bottom-width:1px;background-color:#f6f6f6;margin-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 		<!-- wp:group {"style":{"spacing":{"blockGap":"80px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","verticalAlignment":"bottom"}} -->
 		<div class="wp-block-group">
 			<!-- wp:wporg/site-screenshot /-->

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -8,9 +8,9 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)">
-	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"},"top":{},"right":{},"left":{}}},"layout":{"type":"constrained"}} -->
-	<div class="wp-block-group alignfull" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-style:solid;border-bottom-width:1px;margin-bottom:var(--wp--preset--spacing--50)">
-		<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","verticalAlignment":"bottom"}} -->
+	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|40"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"}},"color":{"background":"#f6f6f6"}},"className":"has-feature-color-background","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull has-feature-color-background has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-style:solid;border-bottom-width:1px;background-color:#f6f6f6;margin-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--40)">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"80px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","verticalAlignment":"bottom"}} -->
 		<div class="wp-block-group">
 			<!-- wp:wporg/site-screenshot /-->
 	

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -1,14 +1,8 @@
 <!-- wp:template-part {"slug":"header","className":"has-display-contents"} /-->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"16px","bottom":"16px"}}},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-small-font-size" style="padding-top:16px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:16px;padding-left:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:wporg/site-breadcrumbs /-->
-</div>
-<!-- /wp:group -->
-
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"bottom":"var:preset|spacing|80"}}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content" style="padding-bottom:var(--wp--preset--spacing--80)">
-	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"}},"color":{"background":"#f6f6f6"}},"className":"has-feature-color-background","layout":{"type":"constrained","wideSize":"1760px"}} -->
+	<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"},"padding":{"top":"var:preset|spacing|40","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}},"border":{"bottom":{"color":"var:preset|color|light-grey-1","style":"solid","width":"1px"}},"color":{"background":"#f6f6f6"}},"className":"has-feature-color-background","layout":{"type":"constrained","wideSize":"1440px"}} -->
 	<div class="wp-block-group alignfull has-feature-color-background has-background" style="border-bottom-color:var(--wp--preset--color--light-grey-1);border-bottom-style:solid;border-bottom-width:1px;background-color:#f6f6f6;margin-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
 		<!-- wp:group {"style":{"spacing":{"blockGap":"80px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","verticalAlignment":"bottom"}} -->
 		<div class="wp-block-group">


### PR DESCRIPTION
Fixes #138. This adds a field in the editor to set a custom color for each site. It can use the generated color from local images (if an image has been uploaded). If no image is found and no color is set, it falls back to `#f6f6f6`. This PR also updates the image sizes of the upload and the mshots request to use the latest viewport & image sizes.

<img width="276" alt="Screenshot 2023-08-03 at 1 04 18 PM" src="https://github.com/WordPress/wporg-showcase-2022/assets/541093/59cf0212-d59f-4a1f-ad9a-38a9c1c54903">

cc @wordpress/meta-design — Does this editor flow make sense? Is this what you expected for color management? You can view the frontend screenshots too, but the spacing/etc is probably not right because it seems to be still in flux.

**Screenshots**

On the frontend, the color is used as the header background color.

| Default | Generated from local image | Manually set color |
|---|---|---|
| ![site-default](https://github.com/WordPress/wporg-showcase-2022/assets/541093/6a2b5593-2141-43e0-a3fc-c9b9170bcb94) | ![site-image](https://github.com/WordPress/wporg-showcase-2022/assets/541093/0ba17421-ef3e-4a35-9c64-6875731bbc01) | ![site-manual](https://github.com/WordPress/wporg-showcase-2022/assets/541093/0fd80b85-a7d0-474e-84cd-b65702839ca4) |

In the editor, the input can be found in the "Post" sidebar, under the Screenshots panel. If there is a local image, the toggle option to use it appears. If the generated color from the image looks bad, the toggle can be turned off and a custom color can be set. If there is no local image, the toggle does not appear, and the only option is custom or `#f6f6f6`.

| | Screenshot |
|---|---|
| No local image, default value | ![site-editor-default](https://github.com/WordPress/wporg-showcase-2022/assets/541093/0f390988-1343-441e-ada0-2939937afecc) |
| No local image, custom value | ![site-editor-manual](https://github.com/WordPress/wporg-showcase-2022/assets/541093/799ec7bb-5c40-452c-977e-46b05cc68e34) |
| Local image, uses image color | ![site-editor-image](https://github.com/WordPress/wporg-showcase-2022/assets/541093/e108cf78-88b0-49f6-b189-508b9b1ef1c7) |
| Local image, override with custom color | ![site-editor-image-manual](https://github.com/WordPress/wporg-showcase-2022/assets/541093/cc0fe6a1-44b7-40c9-9f7b-1305831dd251) |

**To test**

You can test this all in one post, or create a few with different settings. This flow should hit all the major UI points.

1. Edit a site post
2. Set a color
3. View the post, it should use that color
4. Edit again
5. Reset the color
6. View the post, it should use `#f6f6f6`
7. Upload an image to use as the Desktop screenshot
8. The color section should display the active toggle
9. View the post, it should use a color from your image
10. Edit again, disable the toggle
11. View the post, it should use `#f6f6f6`
12. Edit again, set a custom color
13. View the post, it should use your custom color

Try various combinations of images, colors, etc.