### PR TITLE
Single Site: Update site meta list

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -9,10 +9,10 @@
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:columns {"align":"wide"} -->
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"left":"var:preset|spacing|80"}}}} -->
 	<div class="wp-block-columns alignwide">
-		<!-- wp:column {"width":"66.66%"} -->
-		<div class="wp-block-column" style="flex-basis:66.66%">
+		<!-- wp:column {"width":"70%","layout":{"type":"constrained","justifyContent":"left"}} -->
+		<div class="wp-block-column" style="flex-basis:70%">
 			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"}}},"fontSize":"heading-2"} /-->
 
 			<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"},"padding":{"bottom":"var:preset|spacing|10"}}},"className":"external-link"} -->
@@ -23,17 +23,21 @@
 		</div>
 		<!-- /wp:column -->
 
-		<!-- wp:column {"width":"33.33%"} -->
-		<div class="wp-block-column" style="flex-basis:33.33%">
-			<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}},"border":{"radius":"2px"}},"backgroundColor":"blueberry-4"} -->
-			<div class="wp-block-group has-blueberry-4-background-color has-background" style="border-radius:2px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)">
-				<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"600"}},"fontSize":"normal","fontFamily":"inter"} -->
-				<h2 class="has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:600"><?php esc_attr_e( 'More about this site', 'wporg' ); ?></h2>
+		<!-- wp:column {"width":"30%"} -->
+		<div class="wp-block-column" style="flex-basis:30%">
+			<!-- wp:group {"style":{"border":{"radius":"2px","style":"solid","width":"1px"}},"borderColor":"light-grey-1"} -->
+			<div class="wp-block-group has-border-color has-light-grey-1-border-color" style="border-style:solid;border-width:1px;border-radius:2px">
+				<!-- wp:heading {"className":"screen-reader-text"} -->
+				<h2 class="wp-block-heading screen-reader-text"><?php esc_attr_e( 'More about this site', 'wporg' ); ?></h2>
 				<!-- /wp:heading -->
 
 				<!-- wp:wporg/site-meta-list /-->
 			</div>
 			<!-- /wp:group -->
+
+			<!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30"}}}} -->
+			<p style="margin-top:var(--wp--preset--spacing--30)"><a href="<?php echo esc_url( home_url( '/tags/' ) ); ?>"><?php _e( 'View all tags', 'wporg' ); ?></a></p>
+			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
 	</div>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -1,39 +1,31 @@
-.wp-block-wporg-site-meta-list dl {
-	margin: 0;
-}
+.wp-block-wporg-site-meta-list {
+	margin-block-start: 0;
 
-.wp-block-wporg-site-meta-list dl > div {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-}
-
-.wp-block-wporg-site-meta-list dd {
-	word-break: break-word;
-	margin: 0 0 var(--wp--preset--spacing--10);
-}
-
-.wp-block-wporg-site-meta-list dl > div:last-child dd:last-child {
-	margin-bottom: 0;
-}
-
-.wp-block-wporg-site-meta-list dt {
-	white-space: nowrap;
-	padding-right: 1rem;
-}
-
-@media (min-width: 390px) {
-	.wp-block-wporg-site-meta-list dl > div {
-		grid-template-columns: 0.6fr 1fr;
-	}
-}
-
-@media (min-width: 641px) {
-	.wp-block-wporg-site-meta-list dl {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
+	ul {
+		margin: 0;
+		padding: 0;
+		list-style-type: none;
 	}
 
-	.wp-block-wporg-site-meta-list dd:last-child {
-		margin-bottom: 0;
+	li {
+		display: flex;
+		gap: var(--wp--preset--spacing--10);
+		padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
+		border-bottom: 1px solid var(--wp--preset--color--light-grey-1);
+
+		&:last-of-type {
+			border-bottom: none;
+		}
+
+		strong {
+			flex-shrink: 0;
+			font-weight: 400;
+		}
+
+		span {
+			margin-inline-start: auto;
+			text-align: right;
+			color: var(--wp--preset--color--charcoal-3);
+		}
 	}
 }


### PR DESCRIPTION
See #132 — The site information section has been redesigned to list out each meta value and taxonomy separately. It also updates the layout of the single site page to better match the design, though with the spacing conversation ongoing I didn't aim for perfection.

The taxonomy values are links (so you can click to navigate to all sites tagged "dining"),  while the meta field items are not links (there was no plan to allow filtering by these).

## Screenshots

Some examples of different sites with various meta filled in or not.

<table role="table">
<tbody>
<tr>
<td><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/541093/259217477-621e8518-3404-4958-9c8f-f7dd8ef1a991.png"><img src="https://user-images.githubusercontent.com/541093/259217477-621e8518-3404-4958-9c8f-f7dd8ef1a991.png" alt="Screen Shot 2023-08-08 at 14 50 00" style="max-width: 100%;"></a></td>
<td><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/541093/259217497-8fd5c6b1-1e1d-4045-b426-e1eee0279aa5.png"><img src="https://user-images.githubusercontent.com/541093/259217497-8fd5c6b1-1e1d-4045-b426-e1eee0279aa5.png" alt="Screen Shot 2023-08-08 at 14 50 16" style="max-width: 100%;"></a></td>
<td><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/541093/259217507-7a9faf8e-8b4c-4a30-ac12-ce490b4c08f5.png"><img src="https://user-images.githubusercontent.com/541093/259217507-7a9faf8e-8b4c-4a30-ac12-ce490b4c08f5.png" alt="Screen Shot 2023-08-08 at 14 50 33" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>

## To test

1. Check out the branch and build it
2. View a site
3. It should list the post meta, empty values are not shown
4. View other sites, or update fields in the editor
5. Site meta should display as expected
