### PR TITLE
Homepage: Add hero section for random featured site

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/images/dots-dark.svg
+++ b/source/wp-content/themes/wporg-showcase-2022/images/dots-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="55" height="55" fill="none" viewBox="0 0 55 55">
+  <circle cx="50%" cy="50%" r="2.5" fill="#40464D"/>
+</svg>

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_site-hero.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_site-hero.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Title: Site Hero (Featured)
+ * Slug: wporg-showcase-2022/site-hero
+ * Inserter: no
+ *
+ * This renders a random single sticky (hero featured) site.
+ */
+
+?>
+<!-- wp:query {"queryId":0,"query":{"perPage":"1","pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"rand","author":"","search":"","exclude":[],"sticky":"only","inherit":false},"className":"is-section-site-hero"} -->
+<div class="wp-block-query is-section-site-hero">
+	<!-- wp:post-template -->
+		<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|50"}}}} -->
+		<div class="wp-block-columns">
+			<!-- wp:column {"width":"24%"} -->
+			<div class="wp-block-column" style="flex-basis:24%">
+				<!-- wp:group {"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group">
+					<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+					<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+					<!-- /wp:spacer -->
+
+					<!-- wp:heading {"fontSize":"heading-2"} -->
+					<h1 class="wp-block-heading has-heading-2-font-size"><?php esc_attr_e( 'Showcase', 'wporg' ); ?></h1>
+					<!-- /wp:heading -->
+
+					<!-- wp:paragraph {style":{"spacing":{"margin":{"top":"var:preset|spacing|10"}}}} -->
+					<p style="margin-top:var(--wp--preset--spacing--10)"><?php esc_attr_e( 'Star-studded sites built with WordPress', 'wporg' ); ?></p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:wporg/site-meta-list {"meta":["author","domain","category"],"showLabel":false,"style":{"elements":{"link":{"color":{"text":"var:preset|color|blueberry-2"}}},"border":{"radius":"2px","style":"solid","width":"1px"},"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"borderColor":"charcoal-3","textColor":"light-grey-2"} /-->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column {"verticalAlignment":"bottom"} -->
+			<div class="wp-block-column is-vertically-aligned-bottom">
+				<!-- wp:cover {"url":"http://localhost:8888/wp-content/themes/wporg-showcase-2022/images/dots-dark.svg","isRepeated":true,"dimRatio":0,"focalPoint":{"x":0.5,"y":0},"minHeight":440,"contentPosition":"bottom center","style":{"spacing":{"padding":{"top":"70px","right":"70px","bottom":"0","left":"70px"}}},"layout":{"type":"constrained"}} -->
+				<div class="wp-block-cover is-repeated has-custom-content-position is-position-bottom-center" style="padding-top:70px;padding-right:70px;padding-bottom:0;padding-left:70px;min-height:440px">
+					<span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
+					<div role="img" class="wp-block-cover__image-background is-repeated" style="background-position:50% 0%;background-image:url(http://localhost:8888/wp-content/themes/wporg-showcase-2022/images/dots-dark.svg)"></div>
+					<div class="wp-block-cover__inner-container">
+						<!-- wp:wporg/site-screenshot {"isLink":true} /-->
+					</div>
+				</div>
+				<!-- /wp:cover -->
+			</div>
+			<!-- /wp:column -->
+		</div>
+		<!-- /wp:columns -->
+	<!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/front-page.php
@@ -6,11 +6,9 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40","right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"charcoal-2","textColor":"white","className":"has-color","layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull has-color has-white-color has-charcoal-2-background-color has-text-color has-background" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:paragraph -->
-	<p>Slider…</p>
-	<!-- /wp:paragraph -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}}},"backgroundColor":"charcoal-1","textColor":"white","className":"has-color","layout":{"type":"constrained","wideSize":"1760px"}} -->
+<div class="wp-block-group alignfull has-color has-white-color has-charcoal-1-background-color has-text-color has-background" style="padding-right:var(--wp--preset--spacing--edge-space);padding-left:var(--wp--preset--spacing--edge-space)">
+	<!-- wp:pattern {"slug":"wporg-showcase-2022/site-hero"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
@@ -25,6 +25,14 @@
 		}
 	}
 
+	.is-section-site-hero & {
+		max-width: none;
+		border-width: 20px;
+		border-bottom-width: 0;
+		border-radius: 30px 30px 0 0; // 30 = 10px inner radius plus the 20px border size.
+		border-color: var(--wp--preset--color--charcoal-2) !important;
+	}
+
 	a {
 		display: block;
 

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -13,6 +13,22 @@ a:where(:not(.wp-element-button)):focus-visible {
 	border-radius: 2px;
 }
 
+/* Site Hero section */
+.is-section-site-hero {
+
+	/* Switch down to one column when image gets squished. */
+	@media (max-width: 1179px) {
+		.wp-block-columns {
+			flex-direction: column;
+			gap: 0;
+		}
+
+		.wp-block-cover {
+			min-height: 0 !important;
+		}
+	}
+}
+
 /* Style the site grid. */
 .wp-block-query .is-layout-grid {
 	.wp-block-post-title {


### PR DESCRIPTION
Fixes #135. This adds a random site to the header as a "hero". The site is chosen from the "sticky posts" to avoid creating a second Featured category (the current category "Featured" is used for the homepage grid). The same approach was used in the first redesign iteration, see https://github.com/WordPress/wporg-showcase-2022/pull/37.

The Hero section displays a heading & blurb for Showcase, then the featured site's meta: author, domain, and category (should this be tags?).

| Has all 3 meta fields | Missing "author" | 
|---|---|
| ![Screen Shot 2023-08-14 at 18 11 34](https://github.com/WordPress/wporg-showcase-2022/assets/541093/653cc073-c18e-4dc8-a98f-8e4f9809d028) | ![Screen Shot 2023-08-14 at 18 11 18](https://github.com/WordPress/wporg-showcase-2022/assets/541093/88b67e79-6d42-4c25-acb0-c5cdf8ae50b4) |

The responsive styles are a work in progress, this will depend on how the spacing conversation goes I think. Currently the hero breaks into one column at 1179px, because that's when the image starts to look too squished. At 480px, the spacing and border are definitely too big, but that also depends on the outcome of [the spacing issue](https://github.com/WordPress/wporg-main-2022/issues/296).

| 1080px | 1000px | 480px |
|---|---|---|
| ![Screen Shot 2023-08-14 at 18 29 51](https://github.com/WordPress/wporg-showcase-2022/assets/541093/969c32d8-f659-46f8-a7ae-0502a1538267) | ![Screen Shot 2023-08-14 at 18 27 09](https://github.com/WordPress/wporg-showcase-2022/assets/541093/8d3b1419-c6a3-43be-94f0-58150061cdd8) | ![Screen Shot 2023-08-14 at 18 27 26](https://github.com/WordPress/wporg-showcase-2022/assets/541093/37e73c90-249a-480f-a2a9-ccca75f5d3fb) |

**To test**

- Check out branch and build
- Add some sticky posts
- View the homepage
- It should show one of the sites you made sticky
- The site info should show, and the desktop-sized image should be a link to the site detail page
- Reload (maybe a few times if only a few sticky), the featured site should change randomly

Due to the override we're using to fix [this issue](https://github.com/WordPress/gutenberg/issues/41184), if you don't have any sticky posts, it will show any random site.