### PR TITLE
Add "Site Link" block

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -7,6 +7,7 @@ use function WordPressdotorg\Theme\Showcase_2022\Site_Screenshot\get_site_screen
 // Block files
 require_once __DIR__ . '/src/link-group/index.php';
 require_once __DIR__ . '/src/site-edit-link/index.php';
+require_once __DIR__ . '/src/site-link/index.php';
 require_once __DIR__ . '/src/site-meta-list/index.php';
 require_once __DIR__ . '/src/site-screenshot/index.php';
 require_once __DIR__ . '/inc/shortcodes.php';

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -15,9 +15,7 @@
 		<div class="wp-block-column" style="flex-basis:70%">
 			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"}}},"fontSize":"heading-2"} /-->
 
-			<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|20"},"padding":{"bottom":"var:preset|spacing|10"}}},"className":"external-link"} -->
-			<p class="external-link" style="margin-bottom:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--10)"><a href="[domain]" target="_blank" rel="noopener noreferrer">[pretty_domain]</a></p>
-			<!-- /wp:paragraph -->
+			<!-- wp:wporg/site-link /-->
 
 			<!-- wp:post-content /-->
 		</div>

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -15,7 +15,7 @@
 		<div class="wp-block-column" style="flex-basis:70%">
 			<!-- wp:post-title {"level":1,"style":{"spacing":{"margin":{"bottom":"0"}}},"fontSize":"heading-2"} /-->
 
-			<!-- wp:wporg/site-link /-->
+			<!-- wp:wporg/site-link {"style":{"spacing":{"margin":{"top":"4px"}}}} /-->
 
 			<!-- wp:post-content /-->
 		</div>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-link/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-link/block.json
@@ -1,0 +1,39 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "wporg/site-link",
+	"version": "0.1.0",
+	"title": "Site Link",
+	"category": "design",
+	"icon": "",
+	"description": "Displays a pretty link to the site.",
+	"textdomain": "wporg",
+	"supports": {
+		"align": true,
+		"anchor": true,
+		"color": {
+			"gradients": false,
+			"link": true
+		},
+		"html": false,
+		"spacing": {
+			"blockGap": false,
+			"margin": true,
+			"padding": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalWritingMode": true
+		}
+	},
+	"usesContext": [ "postId" ],
+	"editorScript": "file:./index.js",
+	"style": "file:./style-index.css"
+}

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-link/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-link/block.json
@@ -25,12 +25,10 @@
 			"fontSize": true,
 			"lineHeight": true,
 			"__experimentalFontFamily": true,
-			"__experimentalTextDecoration": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
-			"__experimentalTextTransform": true,
-			"__experimentalWritingMode": true
+			"__experimentalTextTransform": true
 		}
 	},
 	"usesContext": [ "postId" ],

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-link/index.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-link/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import './style.scss';
+
+function Edit( { attributes, name } ) {
+	return (
+		<div { ...useBlockProps() }>
+			<ServerSideRender block={ name } attributes={ attributes } skipBlockSupportAttributes />
+		</div>
+	);
+}
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null,
+} );

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-link/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-link/index.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Block Name: Site Link
+ * Description: Displays a pretty link to the site.
+ *
+ * @package wporg
+ */
+
+namespace WordPressdotorg\Theme\Showcase_2022\Site_Link;
+
+add_action( 'init', __NAMESPACE__ . '\init' );
+
+/**
+ * Render the block content.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the block markup.
+ */
+function render( $attributes, $content, $block ) {
+	if ( ! isset( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$post_id = $block->context['postId'];
+	$domain = get_post_meta( $post_id, 'domain', true );
+	if ( ! $domain ) {
+		return '';
+	}
+
+	$pretty_domain = str_replace( 'www.', '', parse_url( $domain, PHP_URL_HOST ) );
+
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'external-link' ) );
+	return sprintf(
+		'<p %1$s><a href="%2$s" target="_blank" rel="noopener noreferrer">%3$s</a></p>',
+		$wrapper_attributes,
+		esc_url( $domain ),
+		esc_html( $pretty_domain )
+	);
+}
+
+/**
+ * Registers the block using the metadata loaded from the `block.json` file.
+ * Behind the scenes, it registers also all assets so they can be enqueued
+ * through the block editor in the corresponding context.
+ *
+ * @see https://developer.wordpress.org/reference/functions/register_block_type/
+ */
+function init() {
+	register_block_type(
+		dirname( dirname( __DIR__ ) ) . '/build/site-link',
+		array(
+			'render_callback' => __NAMESPACE__ . '\render',
+		)
+	);
+}

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-link/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-link/style.scss
@@ -1,0 +1,11 @@
+.wp-block-wporg-site-link {
+	a {
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			text-decoration: underline;
+			text-decoration-thickness: 1px;
+		}
+	}
+}


### PR DESCRIPTION
This simplifies the single template by switching from a paragraph block with shortcodes to a new, custom `wporg/site-link` block. This also allows for switching the underline style from default (underlined) to no underline until hover.

See #132

**Screenshots**

<img width="251" alt="Screenshot 2023-08-30 at 5 51 15 PM" src="https://github.com/WordPress/wporg-showcase-2022/assets/541093/71817acc-7da7-4080-bcfa-114d78933cad">
<img width="409" alt="Screenshot 2023-08-30 at 5 51 26 PM" src="https://github.com/WordPress/wporg-showcase-2022/assets/541093/908d7b66-208b-4512-9d85-d7e2940ce6e8">
