### PR TITLE
Footer: switch styling of footer CTA.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_footer.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_footer.php
@@ -20,8 +20,8 @@
 
 		<!-- wp:buttons -->
 		<div class="wp-block-buttons">
-			<!-- wp:button {"className":"is-style-outline-on-dark"} -->
-			<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( __( 'https://wordpress.org/download/', 'wporg' ) ); ?>"><?php _e( 'Get WordPress', 'wporg' ); ?></a></div>
+			<!-- wp:button -->
+			<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( __( 'https://wordpress.org/download/', 'wporg' ) ); ?>"><?php _e( 'Get WordPress', 'wporg' ); ?></a></div>
 			<!-- /wp:button -->
 		</div>
 		<!-- /wp:buttons -->
@@ -40,8 +40,8 @@
 
 		<!-- wp:buttons -->
 		<div class="wp-block-buttons">
-			<!-- wp:button -->
-			<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( home_url( '/submit-a-wordpress-site/' ) ); ?>"><?php _e( 'Submit a site', 'wporg' ); ?></a></div>
+			<!-- wp:button {"className":"is-style-outline-on-dark"} -->
+			<div class="wp-block-button is-style-outline-on-dark"><a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( home_url( '/submit-a-wordpress-site/' ) ); ?>"><?php _e( 'Submit a site', 'wporg' ); ?></a></div>
 			<!-- /wp:button -->
 		</div>
 		<!-- /wp:buttons -->


### PR DESCRIPTION
Closes #174 

Switch CTA button styles on the footer.

## Screenshot

![image](https://github.com/WordPress/wporg-showcase-2022/assets/18050944/3789a165-7413-435a-8ab6-f973540eac01)
