### PR TITLE
Archives: Update the main heading on all filter views

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -394,6 +394,10 @@ function document_title( $parts ) {
 		} elseif ( is_category() ) {
 			// translators: %s: The name of the tag
 			$parts['title'] = sprintf( __( 'Sites categorized as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
+		} else {
+			$term_names = wp_list_pluck( get_applied_filter_list(), 'name' );
+			// translators: %s list of terms used for filtering.
+			$parts['title'] = sprintf( __( 'Sites filtered by: %s', 'wporg' ), implode( ', ', $term_names ) );
 		}
 
 		// If results are paged and the max number of pages is known.

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -225,6 +225,41 @@ function get_site_domain( $post, $rem_trail_slash = false ) {
 }
 
 /**
+ * Get a list of the currently-applied filters.
+ *
+ * @param boolean $include_search Whether the result should include the search term.
+ *
+ * @return array
+ */
+function get_applied_filter_list( $include_search = true ) {
+	global $wp_query;
+	$terms = [];
+	$taxes = [
+		'tag' => 'post_tag',
+		'cat' => 'category',
+		'category_name' => 'category',
+		'flavor' => 'flavor',
+	];
+	foreach ( $taxes as $query_var => $taxonomy ) {
+		if ( ! isset( $wp_query->query[ $query_var ] ) ) {
+			continue;
+		}
+		$values = (array) $wp_query->query[ $query_var ];
+		foreach ( $values as $value ) {
+			$key = ( 'cat' === $query_var ) ? 'id' : 'slug';
+			$term = get_term_by( $key, $value, $taxonomy );
+			if ( $term ) {
+				$terms[] = $term;
+			}
+		}
+	}
+	if ( $include_search && isset( $wp_query->query['s'] ) ) {
+		$terms[] = array( 'name' => $wp_query->query['s'] );
+	}
+	return $terms;
+}
+
+/**
  * Update the excerpt length.
  *
  * @return string

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_site-grid.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_site-grid.php
@@ -35,7 +35,7 @@
 	<div style="margin-top:0;margin-bottom:0;height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 	<!-- /wp:spacer -->
 
-	<!-- wp:query-title {"type":"archive","className":"screen-reader-text"} /-->
+	<!-- wp:query-title {"type":"filter","className":"screen-reader-text"} /-->
 
 	<!-- wp:post-template {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|40"}},"layout":{"type":"grid","columnCount":3}} -->
 		<!-- wp:wporg/site-screenshot {"isLink":true,"lazyLoad":true,"location":"grid"} /-->


### PR DESCRIPTION
Fixes #180 — This updates the query-title block so that it always outputs heading text on filtered archive views. The heading is still invisible, it's currently there for screen reader users & SEO. 

For example:

- `/archives/?tag[]=dining` — "Filter by: Dining"
- `/archives/?tag[]=dining&cat[]=3` — "Filter by: Dining, Featured"
- `/archives/?cat[]=3&s=restaurant` — Filter by: Featured, restaurant

**To test**

Try any number of filter combinations on the archives page. There should always be an h1 on the page, and the title should match the current filters. You can use [a bookmarklet like this one](https://hinderlingvolkart.github.io/h123/) to test.

Also check the document title, it should reflect the currently-selected filters too.

If you want, switch out the `query-title` in `patterns/_site-grid.php` with the following, for a visible heading.

```
<!-- wp:query-title {"type":"filter","style":{"spacing":{"margin":{"top":"-20px","bottom":"var:preset|spacing|40"}}}} /-->
```
