### PR TITLE
Redirect single term filter pages to their canonical archive URLs

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -27,6 +27,7 @@ add_filter( 'excerpt_length', __NAMESPACE__ . '\modify_excerpt_length', 999 );
 add_filter( 'excerpt_more', __NAMESPACE__ . '\modify_excerpt_more' );
 add_filter( 'query_loop_block_query_vars', __NAMESPACE__ . '\modify_query_loop_block_query_vars', 10, 2 );
 add_filter( 'wporg_noindex_request', __NAMESPACE__ . '\set_noindex' );
+add_action( 'template_redirect', __NAMESPACE__ . '\redirect_term_archives' );
 add_action( 'wp', __NAMESPACE__ . '\jetpack_remove_rp', 20 );
 add_filter( 'jetpack_images_get_images', __NAMESPACE__ . '\jetpack_fallback_image', 10, 3 );
 add_filter( 'jetpack_related_posts_display_markup', __NAMESPACE__ . '\jetpack_related_posts_display', 10, 4 );
@@ -544,4 +545,29 @@ function jetpack_redirect_submission_form( $redirect ) {
 		return home_url( $redirect );
 	}
 	return $redirect;
+}
+
+/**
+ * Redirect category and tag archives to their canonical URLs.
+ *
+ * This prevents double URLs for every category/tag, e.g.,
+ * `/archives/?tag[]=cuisine` and `/tag/cuisine/`.
+ */
+function redirect_term_archives() {
+	global $wp_query;
+	$terms = get_applied_filter_list( false );
+	// True on the `/tag/…` URLs, and false on `/archive/?tag…` URLs.
+	$is_term_archive = is_tag() || is_category() || is_tax();
+
+	// If there is only one term applied, and we're not already on a term
+	// archive, redirect to the main term archive URL.
+	if ( count( $terms ) === 1 && ! $is_term_archive ) {
+		$url = get_term_link( $terms[0] );
+		// Pass through search query.
+		if ( isset( $wp_query->query['s'] ) ) {
+			$url = add_query_arg( 's', $wp_query->query['s'], $url );
+		}
+		wp_safe_redirect( $url );
+		exit;
+	}
 }


### PR DESCRIPTION
Currently, all terms on the site have two URLs, the filter on the archive page and the core-provided term archive. This PR redirects requests from the archive page to the term archive when there's only one term selected.

For example, these are two URLS to the same page:

- https://wordpress.org/showcase-v2/tag/culture/ (if you click the link on a showcase site)
- https://wordpress.org/showcase-v2/archives/?tag%5B%5D=culture (if you only apply one tag)

The same code renders both pages (more or less), and the filters work regardless of the page you started on, so we should pick one as primary. The URL for the core term archive is nicer, so I think that's the one to use.

**To test**

- Start on home or all sites
- Apply a single filter in the dropdown
- The resulting URL should be nice, like `/category/featured/`, etc.
- Try applying other filters, they should still work (the URL is now `/archive/?…`)
- If you search then filter, it should retain the search term (ex, `/category/featured/?s=restaurant`)

You can manually test too,  `/archives/?tag%5B%5D=design` should redirect to `/tag/design`.