### PR TITLE
Add more space between the dots spacer and content.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/templates/page-browse.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page-browse.html
@@ -8,8 +8,8 @@
 
 <!-- wp:group {"align":"full","layout":{"type":"constrained","wideSize":"1760px"}} -->
 <div class="wp-block-group alignfull">
-	<!-- wp:spacer {"height":"60px","align":"wide","className":"has-dots-background","style":{"spacing":{"margin":{"top":"0","bottom":"var:preset|spacing|50"}}}} -->
-	<div style="margin-top:0;margin-bottom:var(--wp--preset--spacing--50);height:60px" aria-hidden="true" class="wp-block-spacer alignwide has-dots-background"></div>
+	<!-- wp:spacer {"height":"60px","align":"wide","className":"has-dots-background","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} -->
+	<div style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50);height:60px" aria-hidden="true" class="wp-block-spacer alignwide has-dots-background"></div>
 	<!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -20,8 +20,8 @@
 
 <!-- wp:group {"align":"full","layout":{"type":"constrained","wideSize":"1760px"}} -->
 <div class="wp-block-group alignfull">
-	<!-- wp:spacer {"height":"60px","align":"wide","className":"has-dots-background","style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}}} -->
-	<div style="margin-top:var(--wp--preset--spacing--40);;margin-bottom:var(--wp--preset--spacing--40);height:60px" aria-hidden="true" class="wp-block-spacer alignwide has-dots-background"></div>
+	<!-- wp:spacer {"height":"60px","align":"wide","className":"has-dots-background","style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|40"}}}} -->
+	<div style="margin-top:var(--wp--preset--spacing--80);margin-bottom:var(--wp--preset--spacing--40);height:60px" aria-hidden="true" class="wp-block-spacer alignwide has-dots-background"></div>
 	<!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
Fixes #200 

**Browse**
Bump the top margin to `var(--wp--preset--spacing--50)`, currently set to `0`.

| Current | Proposed |
| ---- | ---- |
| <img width="600" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/4832319/ad68c4e7-44a6-4c59-90e8-77501d9d3ed8"> | <img width="600" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/4832319/2c263cc2-1c06-4468-aaa7-dd4e8aaf64c9"> |

**Single Template**
Bump the top margin to `var(--wp--preset--spacing--80)`, currently set to `var(--wp--preset--spacing--40)`.

| Current | Proposed |
| ---- | ---- |
| <img width="600" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/4832319/66b7134d-23fe-415b-8d8b-eba51f6e158c"> | <img width="600" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/4832319/0cc0bc83-0cee-471b-926c-8966f4208320"> |