### PR TITLE
Update labels in the browse pattern and remove dots.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-browse.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-browse.php
@@ -34,10 +34,6 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:spacer {"height":"60px","className":"has-dots-background"} -->
-		<div style="height:60px" aria-hidden="true" class="wp-block-spacer has-dots-background"></div>
-		<!-- /wp:spacer -->
-
 		<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"large","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} -->
 		<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Tags', 'wporg' ); ?></h2>
 		<!-- /wp:heading -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-browse.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-browse.php
@@ -16,8 +16,8 @@
 
 		<!-- wp:group {"layout":{"type":"default"}} -->
 		<div class="wp-block-group">
-			<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} -->
-			<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Wonderful WordPress websites by category', 'wporg' ); ?></h2>
+			<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"large","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} -->
+			<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Categories', 'wporg' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:wporg/term-grid {"showPostCounts":true} /-->
@@ -26,8 +26,8 @@
 
 		<!-- wp:group {"layout":{"type":"default"}} -->
 		<div class="wp-block-group">
-			<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} -->
-			<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Wonderful WordPress websites by flavor', 'wporg' ); ?></h2>
+			<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"large","fontFamily":"inter"} -->
+			<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Flavors', 'wporg' ); ?></h2>
 			<!-- /wp:heading -->
 
 			<!-- wp:wporg/term-grid {"showPostCounts":true,"term":"flavor"} /-->
@@ -38,8 +38,8 @@
 		<div style="height:60px" aria-hidden="true" class="wp-block-spacer has-dots-background"></div>
 		<!-- /wp:spacer -->
 
-		<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} -->
-		<h2 class="wp-block-heading has-inter-font-family has-normal-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Wonderful WordPress websites by tag', 'wporg' ); ?></h2>
+		<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"large","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} -->
+		<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Tags', 'wporg' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:wporg/tags-archive /-->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-browse.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-browse.php
@@ -34,11 +34,15 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"large","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} -->
-		<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Tags', 'wporg' ); ?></h2>
-		<!-- /wp:heading -->
+		<!-- wp:group {"layout":{"type":"default"}} -->
+		<div class="wp-block-group">
+			<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"large","fontWeight":"400"}},"fontSize":"normal","fontFamily":"inter"} -->
+			<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Tags', 'wporg' ); ?></h2>
+			<!-- /wp:heading -->
 
-		<!-- wp:wporg/tags-archive /-->
+			<!-- wp:wporg/tags-archive /-->
+		</div>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 </div>


### PR DESCRIPTION
Fixes #188 

This PR simplifies the labels in the browse pattern and also removes the dots separator. 


| Current | Updated |
| ---- | ---- |
| <img width="1536" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/4832319/51b2ab9a-9fd1-4746-8a78-9f7ea4d71ee1"> | ![image](https://github.com/WordPress/wporg-showcase-2022/assets/4832319/d8c3fc07-118c-4416-9dc4-2d1840c86c13) |