### PR TITLE
Add breadcrumbs to all pages

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
@@ -371,10 +371,11 @@ function update_site_breadcrumbs( $breadcrumbs ) {
 		return $breadcrumbs;
 	}
 
-	$term_names = get_applied_filter_list( false );
-
-	 // This matches the "posts page", the All Sites page.
+	// `is_home` matches the "posts page", the All Sites page.
+	// `is_archive` matches any core archive (category, date, etc).
 	if ( is_home() || is_archive() ) {
+		// Get the current applied filters (except search, handled above).
+		$term_names = get_applied_filter_list( false );
 		if ( empty( $term_names ) ) {
 			$breadcrumbs[] = array(
 				'url' => false,
@@ -382,6 +383,7 @@ function update_site_breadcrumbs( $breadcrumbs ) {
 			);
 			return $breadcrumbs;
 		}
+
 		$breadcrumbs[] = array(
 			'url' => home_url( '/archives/' ),
 			'title' => __( 'All sites', 'wporg' ),

--- a/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
@@ -17,6 +17,7 @@ add_action( 'wporg_query_filter_in_form', __NAMESPACE__ . '\inject_other_filters
 add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_query' );
 add_filter( 'wporg_block_navigation_menus', __NAMESPACE__ . '\add_site_navigation_menus' );
 add_filter( 'render_block_core/query-title', __NAMESPACE__ . '\update_archive_title', 10, 3 );
+add_filter( 'wporg_block_site_breadcrumbs', __NAMESPACE__ . '\update_site_breadcrumbs' );
 
 /**
  * Update the query total label to reflect "sites" found.
@@ -328,4 +329,72 @@ function update_archive_title( $block_content, $block, $instance ) {
 		);
 	}
 	return $block_content;
+}
+
+/**
+ * Update the breadcrumbs to the current page.
+ */
+function update_site_breadcrumbs( $breadcrumbs ) {
+	// Build up the breadcrumbs from scratch.
+	$breadcrumbs = array(
+		array(
+			'url' => home_url(),
+			'title' => __( 'Home', 'wporg' ),
+		),
+	);
+
+	if ( is_page() ) {
+		$breadcrumbs[] = array(
+			'url' => false,
+			'title' => get_the_title(),
+		);
+		return $breadcrumbs;
+	}
+
+	if ( is_single() ) {
+		$breadcrumbs[] = array(
+			'url' => false,
+			'title' => get_the_title(),
+		);
+		return $breadcrumbs;
+	}
+
+	$term_names = get_applied_filter_list( false );
+
+	 // This matches the "posts page", the All Sites page.
+	if ( is_home() && empty( $term_names ) ) {
+		$breadcrumbs[] = array(
+			'url' => false,
+			'title' => __( 'All sites', 'wporg' ),
+		);
+		return $breadcrumbs;
+	}
+
+	if ( is_search() ) {
+		$breadcrumbs[] = array(
+			'url' => home_url( '/archives/' ),
+			'title' => __( 'All sites', 'wporg' ),
+		);
+		$breadcrumbs[] = array(
+			'url' => false,
+			'title' => __( 'Search results', 'wporg' ),
+		);
+		return $breadcrumbs;
+	}
+
+	if ( ! empty( $term_names ) ) {
+		$breadcrumbs[] = array(
+			'url' => home_url( '/archives/' ),
+			'title' => __( 'All sites', 'wporg' ),
+		);
+
+		$term_names = wp_list_pluck( $term_names, 'name' );
+		$breadcrumbs[] = array(
+			'url' => false,
+			// translators: %s list of terms used for filtering.
+			'title' => implode( ', ', $term_names ),
+		);
+	}
+
+	return $breadcrumbs;
 }

--- a/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
@@ -343,30 +343,19 @@ function update_site_breadcrumbs( $breadcrumbs ) {
 		),
 	);
 
-	if ( is_page() ) {
-		$breadcrumbs[] = array(
-			'url' => false,
-			'title' => get_the_title(),
-		);
-		return $breadcrumbs;
-	}
-
-	if ( is_single() ) {
-		$breadcrumbs[] = array(
-			'url' => false,
-			'title' => get_the_title(),
-		);
-		return $breadcrumbs;
-	}
-
-	$term_names = get_applied_filter_list( false );
-
-	 // This matches the "posts page", the All Sites page.
-	if ( is_home() && empty( $term_names ) ) {
-		$breadcrumbs[] = array(
-			'url' => false,
-			'title' => __( 'All sites', 'wporg' ),
-		);
+	if ( is_page() || is_single() ) {
+		if ( is_page( 'thanks' ) ) {
+			// For thanks, we want to use the parent page title.
+			$breadcrumbs[] = array(
+				'url' => false,
+				'title' => get_the_title( get_post_parent() ),
+			);
+		} else {
+			$breadcrumbs[] = array(
+				'url' => false,
+				'title' => get_the_title(),
+			);
+		}
 		return $breadcrumbs;
 	}
 
@@ -382,7 +371,17 @@ function update_site_breadcrumbs( $breadcrumbs ) {
 		return $breadcrumbs;
 	}
 
-	if ( ! empty( $term_names ) ) {
+	$term_names = get_applied_filter_list( false );
+
+	 // This matches the "posts page", the All Sites page.
+	if ( is_home() || is_archive() ) {
+		if ( empty( $term_names ) ) {
+			$breadcrumbs[] = array(
+				'url' => false,
+				'title' => __( 'All sites', 'wporg' ),
+			);
+			return $breadcrumbs;
+		}
 		$breadcrumbs[] = array(
 			'url' => home_url( '/archives/' ),
 			'title' => __( 'All sites', 'wporg' ),

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-dark.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-dark.php
@@ -8,7 +8,7 @@
  */
 
 ?>
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}},"border":{"top":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"},"right":{},"bottom":{},"left":{}}},"textColor":"white","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
 	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-dark.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-dark.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Title: Local Nav
+ * Slug: wporg-showcase-2022/nav-dark
+ * Inserter: no
+ *
+ * This nav bar also has the site title, so it should be used on interior pages.
+ */
+
+?>
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}},"border":{"top":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"},"right":{},"bottom":{},"left":{}}},"textColor":"white","fontSize":"small"} -->
+	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
+
+	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+<!-- /wp:wporg/local-navigation-bar -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"charcoal-1","textColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull has-white-color has-charcoal-1-background-color has-text-color has-background has-link-color" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /--></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav.php
@@ -8,8 +8,12 @@
  */
 
 ?>
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"17px","bottom":"18px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
+
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull has-white-background-color has-background" style="padding-top:18px;padding-right:var(--wp--preset--spacing--edge-space);padding-bottom:18px;padding-left:var(--wp--preset--spacing--edge-space)"><!-- wp:wporg/site-breadcrumbs {"fontSize":"small"} /--></div>
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -207,6 +207,11 @@ a:where(:not(.wp-element-button)):focus-visible {
 	}
 }
 
+/* Breadcrumbs: Inherit the current color, to support using on dark background with white text. */
+.wp-block-wporg-site-breadcrumbs .is-current-page {
+	color: inherit;
+}
+
 /* Update the background & text color on /thanks page. */
 body.page-template-page-submit-confirmation .wp-site-blocks {
 	background: var(--wp--preset--color--charcoal-1);

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page-thanks.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page-thanks.html
@@ -1,4 +1,4 @@
-<!-- wp:wporg/global-header {"backgroundColor":"charcoal-1"} /-->
+<!-- wp:wporg/global-header {"backgroundColor":"charcoal-1","style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
 <!-- wp:pattern {"slug":"wporg-showcase-2022/nav-dark"} /-->
 

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page-thanks.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page-thanks.html
@@ -1,4 +1,6 @@
-<!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
+<!-- wp:wporg/global-header {"backgroundColor":"charcoal-1"} /-->
+
+<!-- wp:pattern {"slug":"wporg-showcase-2022/nav-dark"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1760px"}} -->
 <main class="wp-block-group" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:wporg/global-header {"backgroundColor":"charcoal-1"} /-->
+<!-- wp:wporg/global-header {"backgroundColor":"charcoal-1","style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
 
 <!-- wp:pattern {"slug":"wporg-showcase-2022/nav-dark"} /-->
 

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -1,6 +1,4 @@
-<!-- wp:wporg/global-header {"backgroundColor":"charcoal-1","style":{"border":{"bottom":{"color":"var:preset|color|white-opacity-15","style":"solid","width":"1px"}}}} /-->
-
-<!-- wp:pattern {"slug":"wporg-showcase-2022/nav-dark"} /-->
+<!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">

--- a/source/wp-content/themes/wporg-showcase-2022/templates/single.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/single.html
@@ -1,4 +1,6 @@
-<!-- wp:template-part {"slug":"header","className":"has-display-contents","tagName":"div"} /-->
+<!-- wp:wporg/global-header {"backgroundColor":"charcoal-1"} /-->
+
+<!-- wp:pattern {"slug":"wporg-showcase-2022/nav-dark"} /-->
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px"}},"className":"entry-content","layout":{"type":"constrained"}} -->
 <main class="wp-block-group entry-content">


### PR DESCRIPTION
Fixes #208 — this adds the Site Breadcrumbs block to all pages except the homepage. It also customizes the output of the block to fit the hierarchy of Showcase. Most pages use the default white background, but single posts (sites) and the submission "Thanks" page use a dark bar.

**Screenshots**

Ignore the site content on my staging site, I haven't updated it since we started. The only relevant change here is the breadcrumb.

No change to home

![b-home](https://github.com/WordPress/wporg-showcase-2022/assets/541093/65f95dc6-89b2-4f9b-93d4-905b80de5c63)

Archives

| All sites | Single filter | Multiple filters | Search results |
|---|---|---|---|
| ![b-archives](https://github.com/WordPress/wporg-showcase-2022/assets/541093/3a28e34c-fbf7-48a0-b019-b3f2b5f00a0e) | ![b-archive-single-filter](https://github.com/WordPress/wporg-showcase-2022/assets/541093/b269a32b-181c-4155-9149-e86b80ddd84e) | ![b-archive-multiple-filters](https://github.com/WordPress/wporg-showcase-2022/assets/541093/b5dad489-0765-494e-ba4a-c5ac77b84510) | ![b-archive-search](https://github.com/WordPress/wporg-showcase-2022/assets/541093/94b054dd-a811-4537-8c47-43f581a9d3ca) |

Singles, note that single sites use a dark background.

| Site | Page (tags page) |
|---|---|
| ![b-single](https://github.com/WordPress/wporg-showcase-2022/assets/541093/73a8f9f5-636b-47e6-a342-90eebf830157) | ![b-filters](https://github.com/WordPress/wporg-showcase-2022/assets/541093/a433dd0e-30c2-488c-8a1d-f9564ccb313e) |

Submission

| Log in | Submission form | Thanks |
|---|---|---|
| ![b-submit-login](https://github.com/WordPress/wporg-showcase-2022/assets/541093/aa52f4d1-3c88-44fa-8080-f55e7ab7cd45) | ![b-submit](https://github.com/WordPress/wporg-showcase-2022/assets/541093/9d4a1955-1124-4c9c-abd3-3bc18372d3fb) | ![b-submit-thanks](https://github.com/WordPress/wporg-showcase-2022/assets/541093/87dde2a5-5cd1-411b-b412-6aad570fa2ff) |
