### PR TITLE
Query Filters: Add taxonomy term counts

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
@@ -70,13 +70,7 @@ function get_post_tag_options( $options ) {
 		_n( 'Popular tags <span>%s</span>', 'Popular tags <span>%s</span>', $count, 'wporg' ),
 		$count
 	);
-	$option_labels = array_map(
-		function( $name, $count ) {
-			return $name . " ($count)";
-		},
-		wp_list_pluck( $tags, 'name' ),
-		wp_list_pluck( $tags, 'count' )
-	);
+	$option_labels = get_option_labels( $tags );
 	return array(
 		'label' => $label,
 		'title' => __( 'Popular tags', 'wporg' ),
@@ -108,14 +102,7 @@ function get_flavor_options( $options ) {
 		_n( 'Flavors <span>%s</span>', 'Flavors <span>%s</span>', $count, 'wporg' ),
 		$count
 	);
-	$option_labels = array_map(
-		function( $name, $count ) {
-			return $name . " ($count)";
-		},
-		wp_list_pluck( $flavors, 'name' ),
-		wp_list_pluck( $flavors, 'count' )
-	);
-
+	$option_labels = get_option_labels( $flavors );
 	return array(
 		'label' => $label,
 		'title' => __( 'Flavors', 'wporg' ),
@@ -162,13 +149,8 @@ function get_category_options( $options ) {
 		_n( 'Categories <span>%s</span>', 'Categories <span>%s</span>', $count, 'wporg' ),
 		$count
 	);
-	$option_labels = array_map(
-		function( $name, $count ) {
-			return $name . " ($count)";
-		},
-		wp_list_pluck( $categories, 'name' ),
-		wp_list_pluck( $categories, 'count' )
-	);
+	$option_labels = get_option_labels( $categories );
+
 	return array(
 		'label' => $label,
 		'title' => __( 'Categories', 'wporg' ),
@@ -420,4 +402,23 @@ function update_site_breadcrumbs( $breadcrumbs ) {
 	}
 
 	return $breadcrumbs;
+}
+
+/**
+ * Get an array of option labels.
+ * Each label is a string formatted as 'name (count)'. e.g, Business (30).
+ *
+ * @param array $taxonomy An arrays with taxonomy terms. e.g., Categories = [ Business, Store, etc. ].
+ * @return array An array of formatted option label strings.
+ */
+function get_option_labels( $taxonomy ) {
+	$option_labels = array_map(
+		function( $name, $count ) {
+			return $name . " ($count)";
+		},
+		wp_list_pluck( $taxonomy, 'name' ),
+		wp_list_pluck( $taxonomy, 'count' )
+	);
+
+	return $option_labels;
 }

--- a/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
+++ b/source/wp-content/themes/wporg-showcase-2022/inc/block-config.php
@@ -70,12 +70,19 @@ function get_post_tag_options( $options ) {
 		_n( 'Popular tags <span>%s</span>', 'Popular tags <span>%s</span>', $count, 'wporg' ),
 		$count
 	);
+	$option_labels = array_map(
+		function( $name, $count ) {
+			return $name . " ($count)";
+		},
+		wp_list_pluck( $tags, 'name' ),
+		wp_list_pluck( $tags, 'count' )
+	);
 	return array(
 		'label' => $label,
 		'title' => __( 'Popular tags', 'wporg' ),
 		'key' => 'tag',
 		'action' => home_url( '/archives/' ),
-		'options' => array_combine( wp_list_pluck( $tags, 'slug' ), wp_list_pluck( $tags, 'name' ) ),
+		'options' => array_combine( wp_list_pluck( $tags, 'slug' ), $option_labels ),
 		'selected' => $selected,
 	);
 }
@@ -101,12 +108,20 @@ function get_flavor_options( $options ) {
 		_n( 'Flavors <span>%s</span>', 'Flavors <span>%s</span>', $count, 'wporg' ),
 		$count
 	);
+	$option_labels = array_map(
+		function( $name, $count ) {
+			return $name . " ($count)";
+		},
+		wp_list_pluck( $flavors, 'name' ),
+		wp_list_pluck( $flavors, 'count' )
+	);
+
 	return array(
 		'label' => $label,
 		'title' => __( 'Flavors', 'wporg' ),
 		'key' => 'flavor',
 		'action' => home_url( '/archives/' ),
-		'options' => array_combine( wp_list_pluck( $flavors, 'slug' ), wp_list_pluck( $flavors, 'name' ) ),
+		'options' => array_combine( wp_list_pluck( $flavors, 'slug' ), $option_labels ),
 		'selected' => $selected,
 	);
 }
@@ -147,12 +162,19 @@ function get_category_options( $options ) {
 		_n( 'Categories <span>%s</span>', 'Categories <span>%s</span>', $count, 'wporg' ),
 		$count
 	);
+	$option_labels = array_map(
+		function( $name, $count ) {
+			return $name . " ($count)";
+		},
+		wp_list_pluck( $categories, 'name' ),
+		wp_list_pluck( $categories, 'count' )
+	);
 	return array(
 		'label' => $label,
 		'title' => __( 'Categories', 'wporg' ),
 		'key' => 'cat',
 		'action' => home_url( '/archives/' ),
-		'options' => array_combine( wp_list_pluck( $categories, 'term_id' ), wp_list_pluck( $categories, 'name' ) ),
+		'options' => array_combine( wp_list_pluck( $categories, 'term_id' ), $option_labels ),
 		'selected' => $selected,
 	);
 }


### PR DESCRIPTION
Closes #225 

This PR adds taxonomy term counts to the filter dropdowns.

<img width="327" alt="Screen Shot 2023-10-09 at 3 59 42 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/021bc62c-6bac-484e-af46-fb54119a5824">
