### PR TITLE
Update the Post Terms block to display categories in the Jetpack Related Posts block.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -531,7 +531,7 @@ function jetpack_related_posts_display( $markup, $post_id, $related_posts, $bloc
 		<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--10)">
 			<!-- wp:post-title {"isLink":true,"level":3,"style":{"typography":{"fontStyle":"normal","fontWeight":"400","lineHeight":"inherit"}},"fontSize":"normal","fontFamily":"inter"} /-->
 
-			<!-- wp:post-terms {"term":"post_tag"} /-->
+			<!-- wp:post-terms {"term":"category"} /-->
 		</div>
 		<!-- /wp:group -->
 	<!-- /wp:post-template -->


### PR DESCRIPTION
The Jetpack Related Posts block currently displays site tags. Since we [switched to displaying categories](https://github.com/WordPress/wporg-showcase-2022/issues/183) in Query loops, it makes sense to update the Related Sites section to display categories as well. 