### PR TITLE
Remove unnecessary blocking style requests

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/inc/block-config.php';
 
 // Filters and Actions
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_assets' );
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\maybe_dequeue_assets' );
 add_action( 'init', __NAMESPACE__ . '\setup_theme' );
 add_action( 'wp_head', __NAMESPACE__ . '\add_social_meta_tags' );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\modify_search_query' );
@@ -39,6 +40,8 @@ add_filter( 'grunion_contact_form_redirect_url', __NAMESPACE__ . '\jetpack_redir
 add_filter( 'grunion_should_send_email', '__return_false' );
 // Enable auto-fill using user information.
 add_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
+// Remove Jetpack CSS on frontend
+add_filter( 'jetpack_implode_frontend_css', '__return_false', 99 );
 
 /**
  * Enqueue scripts and styles.
@@ -54,6 +57,15 @@ function enqueue_assets() {
 		filemtime( __DIR__ . '/build/style/style-index.css' )
 	);
 	wp_style_add_data( 'wporg-showcase-2022-style', 'rtl', 'replace' );
+}
+
+/**
+ * Dequeue or deregister some scripts and styles on frontend for performance.
+ */
+function maybe_dequeue_assets() {
+	if ( ! is_user_logged_in() ) {
+		wp_deregister_style( 'dashicons' );
+	}
 }
 
 /**


### PR DESCRIPTION
See #233 

The [current lighthouse performance score](https://mc.wordpress.org/wporg-site-stats.php?date=2023-10-10) is consistently < 80.

In my sandbox it's between 80 and 90 before these changes. The biggest contributing factor is the LCP metric, and a major factor in that is render blocking styles for dashicons and jetpack:

![Screenshot 2023-10-11 at 12 58 41 PM](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/bc3ba4ec-8a4f-451d-aff1-f9f20b19d73d)

We don't need either of these on the frontend _as far as I can see_, so this PR fixes that opportunity by removing them. This results in a score > 90, due to an improved LCP metric:

![Screenshot 2023-10-11 at 1 00 01 PM](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/186acec7-60d6-45a0-afb9-9532f955f9a2)

The initial server response time is bad for me accessing my sandbox in NZ, and is considerably better in prod, so I think we can work on these resource loading optimisations first, and look at server response next if necessary.

### Testing

Best to use a sandbox to be as close as possible to prod, and an incognito tab so that no extensions can interfere with results. Run a Lighthouse performance test with and without these changes and compare.

Check that Jetpack and the admin in general still have their required CSS loaded.