### PR TITLE
Increase local nav spacing

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-dark.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-dark.php
@@ -11,7 +11,7 @@
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"charcoal-1","textColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-front.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-front.php
@@ -15,5 +15,5 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav.php
@@ -11,7 +11,7 @@
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->


### PR DESCRIPTION
Fixes #236 

Changes the spacing between the local nav items from the default block spacing of 20px to 24px.

I've chosen to use local block styles, rather than updating this across all sites using the local-navigation block styles, as [the current local-navigation styles](https://github.com/WordPress/wporg-mu-plugins/blob/trunk/mu-plugins/blocks/local-navigation-bar/postcss/style.pcss) look like they're lightweight and intended to allow inner blocks to be styled independently.

The downside of this is that the navigation block gap setting doesn't allow independent configuration of column gap and row gap, so the mobile version also gets 24px vertical spacing (see screenshot below). If we controlled this via the local-navigation block styles we could style independently. Is this worth doing @WordPress/meta-design ?

### Screenshots

| Front (_nav-front) | Single (_nav) | Thanks (_nav-dark) |
|-|-|-|
| ![localhost_8888_(Desktop)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/2592bca0-6a19-4510-ab87-b1f5262eae5a) | ![localhost_8888_age-of-union_(Desktop)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/128cd5f1-373f-431a-b10d-fcef94f4685d) | ![localhost_8888_submit-a-wordpress-site_thanks_(Desktop)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/d694e63f-0a72-4683-85de-c82d8d96d9f2) |

#### Mobile

<img src="https://github.com/WordPress/wporg-showcase-2022/assets/1017872/ebfde1bd-ef8c-4104-9738-59f1e90dff09" width="300">