### PR TITLE
Improve screen reader experience on site meta lists

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
@@ -96,15 +96,29 @@ function render( $attributes, $content, $block ) {
 	}
 
 	foreach ( $meta_fields as $field ) {
-		$value = get_value( $field['type'], $field['key'], $block->context['postId'] );
+		list('type' => $type, 'key' => $key, 'label' => $label) = $field;
+		$value = get_value( $type, $key, $block->context['postId'] );
+		$aria_label = $label . ': ' . wp_strip_all_tags( $value );
+
+		// Hide these from values from screen readers as they do not contain links.
+		$aria_hide_value = in_array( $key, array( 'country', 'published' ) )
+			? ' aria-hidden="true"'
+			: '';
+
+		$html_label = $show_label
+			? sprintf( '<strong aria-hidden="true">%1$s</strong>', $label )
+			: '';
 
 		if ( ! empty( $value ) ) {
 			$list_items[] = sprintf(
-				'<li class="is-meta-%1$s"><strong%2$s>%3$s</strong> <span>%4$s</span></li>',
-				$field['key'],
-				$show_label ? '' : ' class="screen-reader-text"',
-				$field['label'],
-				wp_kses_post( $value )
+				'<li class="is-meta-%1$s" aria-label="%2$s">
+					%3$s<span%4$s>%5$s</span>
+				</li>',
+				$key,
+				$aria_label,
+				wp_kses_post( $html_label ),
+				$aria_hide_value,
+				wp_kses_post( $value ),
 			);
 		}
 	}


### PR DESCRIPTION
Fixes #235 

The flex layout on the site meta list items causes the nested elements to be read individually, rather than as a complete `label: value` pair.

This PR adds an `aria-label` attribute on the list items which is read as intended, eg. 'Category: Creative'. Nested elements have `aria-hidden` unless they contain a URL, as this still needs to be accessible. This reduces duplicated content unless necessary.

On the home page the labels are visibly hidden, so there are changes to not render them at all in this case, and rely on the `aria-label` instead.

There is no visual change.

The resulting HTML looks like this:

#### Home 

```html
<ul>
	<li class="is-meta-post_title" aria-label="Site title: Age of Union">
		<span><a href="http://localhost:8888/age-of-union/">Age of Union</a></span>
	</li>
	<li class="is-meta-domain" aria-label="URL: ageofunion.com">
		<span><a class="external-link" href="https://ageofunion.com/" target="_blank" rel="noopener noreferrer">ageofunion.com</a></span>
	</li>
	<li class="is-meta-category" aria-label="Category: Community">
		<span><a href="http://localhost:8888/category/community/" rel="tag">Community</a></span>
	</li>
</ul>
```

#### Single

```html
<ul>
	<li class="is-meta-country" aria-label="Country: Canada">
		<strong aria-hidden="true">Country</strong>
		<span aria-hidden="true">Canada</span>
	</li>
	<li class="is-meta-category" aria-label="Category: Community">
		<strong aria-hidden="true">Category</strong>
		<span><a href="http://localhost:8888/category/community/" rel="tag">Community</a></span>
	</li>
	<li class="is-meta-published" aria-label="Published: September 2023">
		<strong aria-hidden="true">Published</strong>
		<span aria-hidden="true">September 2023</span>
	</li>
	<li class="is-meta-post_tag" aria-label="Site tags: Conservation, Environment, Nonprofit">
		<strong aria-hidden="true">Site tags</strong>
		<span><a href="http://localhost:8888/tag/conservation/" rel="tag">Conservation</a>, <a href="http://localhost:8888/tag/environment/" rel="tag">Environment</a>, <a href="http://localhost:8888/tag/nonprofit/" rel="tag">Nonprofit</a></span>
	</li>
</ul>
```

## Testing

Use a screen reader to navigate the home and single site pages, checking how the screen reader interprets the meta list.

It should announce the list, then read each list item as `label: value`, and you should be able to navigate to the link within if appropriate (only country and published don't have links).

The label text should not be read twice.