### PR TITLE
Fix dots pattern on mobile log in screen & thank you screen

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/log-in.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/log-in.php
@@ -7,39 +7,32 @@
 
 ?>
 
-<!-- wp:cover {"dimRatio":0,"minHeight":45,"minHeightUnit":"vh","isDark":false,"align":"wide","style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}}}} -->
-<div class="wp-block-cover alignwide is-light" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;min-height:45vh">
-	<span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
-	<div class="wp-block-cover__inner-container">
-		<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
-		<div class="wp-block-group alignwide">
-			<!-- wp:heading {"textAlign":"center","level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-3"} -->
-			<h1 class="wp-block-heading alignwide has-text-align-center has-heading-3-font-size" style="margin-bottom:var(--wp--preset--spacing--30)"><?php esc_html_e( 'Log in to submit a site', 'wporg' ); ?></h1>
-			<!-- /wp:heading -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide">
+	<!-- wp:heading {"textAlign":"center","level":1,"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}},"fontSize":"heading-3"} -->
+	<h1 class="wp-block-heading alignwide has-text-align-center has-heading-3-font-size" style="margin-bottom:var(--wp--preset--spacing--30)"><?php esc_html_e( 'Log in to submit a site', 'wporg' ); ?></h1>
+	<!-- /wp:heading -->
 
-			<!-- wp:paragraph {"align":"center"} -->
-			<p class="has-text-align-center"><?php esc_html_e( 'Thanks for your interest in submitting a site to the Showcase!', 'wporg' ); ?></p>
-			<!-- /wp:paragraph -->
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center"><?php esc_html_e( 'Thanks for your interest in submitting a site to the Showcase!', 'wporg' ); ?></p>
+	<!-- /wp:paragraph -->
 
-			<!-- wp:paragraph {"align":"center"} -->
-			<p class="has-text-align-center"><?php
-			printf(
-				/* translators: %s is the login url. */
-				wp_kses_post( __( '<a href="%s">Log in to your WordPress.org account</a> to continue.', 'wporg' ) ),
-				esc_url( wp_login_url( home_url( '/' ) . 'submit-a-wordpress-site' ) )
-			);
-			?></p>
-			<!-- /wp:paragraph -->
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center"><?php
+	printf(
+		/* translators: %s is the login url. */
+		wp_kses_post( __( '<a href="%s">Log in to your WordPress.org account</a> to continue.', 'wporg' ) ),
+		esc_url( wp_login_url( home_url( '/' ) . 'submit-a-wordpress-site' ) )
+	);
+	?></p>
+	<!-- /wp:paragraph -->
 
-			<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
-			<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
-				<!-- wp:image {"align":"center","sizeSlug":"large"} -->
-				<figure class="wp-block-image aligncenter size-large"><img src="<?php echo esc_attr( get_stylesheet_directory_uri() . '/images/star-blue.svg' ); ?>" alt=""/></figure>
-				<!-- /wp:image -->
-			</div>
-			<!-- /wp:group -->
-		</div>
-		<!-- /wp:group -->
+	<!-- wp:group {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:image {"align":"center","sizeSlug":"large"} -->
+		<figure class="wp-block-image aligncenter size-large"><img src="<?php echo esc_attr( get_stylesheet_directory_uri() . '/images/star-blue.svg' ); ?>" alt=""/></figure>
+		<!-- /wp:image -->
 	</div>
+	<!-- /wp:group -->
 </div>
-<!-- /wp:cover -->
+<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -224,7 +224,7 @@ body.page-template-page-submit-confirmation .wp-site-blocks {
 	&.has-dots-background,
 	&.has-dark-dots-background,
 	&.has-blue-dots-background {
-		background-position: top left;
+		background-position: top center;
 		background-repeat: repeat-x;
 		background-size: auto;
 	}

--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -219,18 +219,6 @@ body.page-template-page-submit-confirmation .wp-site-blocks {
 	color: var(--wp--preset--color--white);
 }
 
-body.page-template-page-submit-confirmation,
-body.page-template-page-submit {
-
-	/* Adjust margin used to pull the header over the dots background when the font size changes. */
-	@media (max-width: 599px) {
-		.wp-block-spacer.has-dark-dots-background,
-		.wp-block-spacer.has-blue-dots-background {
-			margin-bottom: -30px !important;
-		}
-	}
-}
-
 /* Add background to spacers. These are custom classes, not attached as block styles. */
 .wp-block-spacer {
 	&.has-dots-background,

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page-log-in.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page-log-in.html
@@ -4,8 +4,8 @@
 <main class="wp-block-group" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
 	<!-- wp:group {"layout":{"type":"constrained","wideSize":"1760px"}} -->
 	<div class="wp-block-group">
-		<!-- wp:spacer {"height":"125px","className":"alignwide has-blue-dots-background","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
-		<div style="margin-top:var(--wp--preset--spacing--50);height:125px" aria-hidden="true" class="wp-block-spacer alignwide has-blue-dots-background"></div>
+		<!-- wp:spacer {"height":"125px","className":"alignwide has-blue-dots-background","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} -->
+		<div style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50);height:125px" aria-hidden="true" class="wp-block-spacer alignwide has-blue-dots-background"></div>
 		<!-- /wp:spacer -->
 	</div>
 	<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/templates/page-thanks.html
+++ b/source/wp-content/themes/wporg-showcase-2022/templates/page-thanks.html
@@ -4,8 +4,8 @@
 
 <!-- wp:group {"tagName":"main","style":{"spacing":{"blockGap":"0px","padding":{"left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"layout":{"type":"constrained","wideSize":"1760px"}} -->
 <main class="wp-block-group" style="padding-left:var(--wp--preset--spacing--edge-space);padding-right:var(--wp--preset--spacing--edge-space)">
-	<!-- wp:spacer {"height":"125px","className":"alignwide has-dark-dots-background","style":{"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} -->
-	<div style="margin-top:var(--wp--preset--spacing--50);height:125px" aria-hidden="true" class="wp-block-spacer alignwide has-dark-dots-background"></div>
+	<!-- wp:spacer {"height":"125px","className":"alignwide has-dark-dots-background","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} -->
+	<div style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50);height:125px" aria-hidden="true" class="wp-block-spacer alignwide has-dark-dots-background"></div>
 	<!-- /wp:spacer -->
 
 	<!-- wp:post-content /-->


### PR DESCRIPTION
Fixes #226 

This PR first removes the style from the old design. Then it also ensures the distance between the dot pattern and the text is between 30-50 (submit page) or ~30 & 70~ **40-60** (Login & Thank you screen). 

Additionally, because the Cover Block has an automatically changing margin-top, it makes the CSS control of the distance more complicated on different screens (On smaller screens, the margin-top of the cover disappears, causing the text and dots pattern to overlap.). Plus, I don't see the necessity of the Cover Block here as we only have text at the moment. It might also be a part of the old design. So it has been removed.

[Figma](https://www.figma.com/file/nK6LcMOZMtRAQdIky3PNIA/Showcase?type=design&node-id=3526-68710&mode=design&t=8ymL9jC6TvFY4MjX-0)

#### Screenshots

|  | Submit Page (margin bottom: 30px-50px) | Login Page (~30px & 70px~ 40px-60px) | Thank You Page (~30px & 70px~ 40px-60px) |
| -- |-- | -- | -- |
| Bigger Screen | <img width="1472" alt="Screen Shot 2023-10-12 at 1 53 37 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/bc4fba2d-b317-46b8-ab00-ac5fb1e2e3d9"> | <img width="1457" alt="Screen Shot 2023-10-12 at 1 52 57 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/55a5037c-9cf3-48b9-88c2-0dc142faef97"> | <img width="1471" alt="Screen Shot 2023-10-12 at 1 53 52 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/6ccf4456-566f-4b9d-9ef4-1dde2e4d7834"> |
| Mobile Screen | <img width="380" alt="Screen Shot 2023-10-12 at 1 54 28 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/128f46da-00af-472c-81f6-ff63d2fc9993"> | <img width="378" alt="Screen Shot 2023-10-12 at 1 54 50 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/287d1c81-5900-46a6-a45d-94c554e6551e"> | <img width="375" alt="Screen Shot 2023-10-12 at 1 54 12 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/ddb5ffb8-f8fe-48f0-843b-bc2c8927a2e2"> |

> [!NOTE]
> ~Currently, the margin between the dot pattern and text on the Login Page and Thank You Page is:~
>
> ~30px in the mobile view and 70px in non-mobile views (> 599px).~
>
> ~This is according to the Figma design. However, if we want a progressive adjustment like the Submit Page (using clamp to vary the margin between 30-50px), the Login Page and Thank You Page can only vary between 40-60px. This is because after the `--wp--preset--spacing--40`, we only have `--wp--preset--spacing--50: clamp(40px, calc(5vw + 10px), 60px);`.~
>
> ~This means the mobile screen would be at 40px (which is acceptable per the previous discussion), and the maximum would be 60px (This hasn't been discussed yet, might need to see if this is acceptable since the Figma design specifies 70px, a difference of 10px)~

👆 --wp--preset--spacing--50 is used eventually as per the feedback in the comment below.

> [!NOTE]
> Only the Cover Block of the login page has been removed here. The Cover Block for the Thank You Page needs to be edited on the website.
