### PR TITLE
Remove Flavors UI

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_site-grid-featured.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_site-grid-featured.php
@@ -24,7 +24,6 @@
 		<div class="wp-block-group wporg-query-filters">
 			<!-- wp:wporg/query-filter {"key":"post_tag"} /-->
 			<!-- wp:wporg/query-filter {"key":"category"} /-->
-			<!-- wp:wporg/query-filter {"key":"flavor"} /-->
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_site-grid.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_site-grid.php
@@ -24,7 +24,6 @@
 		<div class="wp-block-group wporg-query-filters">
 			<!-- wp:wporg/query-filter {"key":"post_tag"} /-->
 			<!-- wp:wporg/query-filter {"key":"category"} /-->
-			<!-- wp:wporg/query-filter {"key":"flavor"} /-->
 			<!-- wp:wporg/query-filter {"key":"sort","multiple":false} /-->
 		</div>
 		<!-- /wp:group -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-browse.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-browse.php
@@ -11,7 +11,7 @@
 	<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"var:preset|spacing|50"}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group alignwide">
 		<!-- wp:heading {"level":1,"fontSize":"heading-3"} -->
-		<h1 class="wp-block-heading has-heading-3-font-size"><?php esc_html_e( 'Browse by category, flavor, or tag', 'wporg' ); ?></h1>
+		<h1 class="wp-block-heading has-heading-3-font-size"><?php esc_html_e( 'Browse by category or tag', 'wporg' ); ?></h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:group {"layout":{"type":"default"}} -->
@@ -21,16 +21,6 @@
 			<!-- /wp:heading -->
 
 			<!-- wp:wporg/term-grid {"showPostCounts":true} /-->
-		</div>
-		<!-- /wp:group -->
-
-		<!-- wp:group {"layout":{"type":"default"}} -->
-		<div class="wp-block-group">
-			<!-- wp:heading {"level":2,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"large","fontFamily":"inter"} -->
-			<h2 class="wp-block-heading has-inter-font-family has-large-font-size" style="font-style:normal;font-weight:400"><?php _e( 'Flavors', 'wporg' ); ?></h2>
-			<!-- /wp:heading -->
-
-			<!-- wp:wporg/term-grid {"showPostCounts":true,"term":"flavor"} /-->
 		</div>
 		<!-- /wp:group -->
 

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/page-single.php
@@ -29,7 +29,7 @@
 				<h2 class="wp-block-heading screen-reader-text"><?php esc_attr_e( 'More about this site', 'wporg' ); ?></h2>
 				<!-- /wp:heading -->
 
-				<!-- wp:wporg/site-meta-list {"meta":["author","country","category","flavor","published","post_tag"],"fontSize":"small","style":{"border":{"radius":"2px","style":"solid","width":"1px"}},"borderColor":"light-grey-1"} /-->
+				<!-- wp:wporg/site-meta-list {"meta":["author","country","category","published","post_tag"],"fontSize":"small","style":{"border":{"radius":"2px","style":"solid","width":"1px"}},"borderColor":"light-grey-1"} /-->
 			</div>
 			<!-- /wp:group -->
 


### PR DESCRIPTION
Closes #230 

This PR removes Flavors from Homepage Filter, Search Page Filter, Archive Page Filter, Browse Page, and Single Page.

|  | Screenshots |
| -- | -- |
| Homepage | <img width="1728" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/cfddd902-14ff-43ad-b843-763f5a97cc0d"> |
| Serach Page | <img width="1726" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/6e35c760-b6b0-42f2-abe1-407fab4bd235"> | 
| Archive Page | <img width="1726" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/79bd63ea-b42c-4344-a5df-0dca78ad338d"> | 
| Browse Page | <img width="1550" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/56ae816a-5636-4e8d-aa73-76d9fcef46b0"> |
|  Single Page | <img width="1728" alt="image" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/b8fbb86c-b7a6-49c0-8894-8161fcfb99be"> |

  



