### PR TITLE
Improve screen reader experience for site meta (v2)

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
@@ -99,12 +99,19 @@ function render( $attributes, $content, $block ) {
 		$value = get_value( $field['type'], $field['key'], $block->context['postId'] );
 
 		if ( ! empty( $value ) ) {
+			$value = wp_kses_post( $value );
+
 			$list_items[] = sprintf(
-				'<li class="is-meta-%1$s"><strong%2$s>%3$s</strong> <span>%4$s</span></li>',
+				'<li class="is-meta-%1$s">
+					<span class="screen-reader-text">%2$s: %3$s</span>
+					<span aria-hidden="true">%4$s</span>
+				</li>',
 				$field['key'],
-				$show_label ? '' : ' class="screen-reader-text"',
 				$field['label'],
-				wp_kses_post( $value )
+				$value,
+				$show_label
+					? sprintf( '<strong>%1$s</strong><span>%2$s</span>', $field['label'], $value )
+					: $value,
 			);
 		}
 	}

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -10,8 +10,6 @@
 	}
 
 	li {
-		display: flex;
-		gap: var(--wp--preset--spacing--10);
 		padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
 		border-bottom: 1px solid;
 		border-color: inherit;
@@ -20,24 +18,29 @@
 			border-bottom: none;
 		}
 
-		strong {
-			flex-shrink: 0;
-			font-weight: 400;
-		}
+		span[aria-hidden="true"] {
+			display: flex;
+			gap: var(--wp--preset--spacing--10);
 
-		span {
-			margin-inline-start: auto;
-			text-align: right;
-			color: var(--wp--preset--color--charcoal-3);
-		}
-
-		@media (max-width: 380px) {
-			flex-direction: column;
-			gap: 0;
+			strong {
+				flex-shrink: 0;
+				font-weight: 400;
+			}
 
 			span {
-				margin-inline-start: unset;
-				text-align: initial;
+				margin-inline-start: auto;
+				text-align: right;
+				color: var(--wp--preset--color--charcoal-3);
+			}
+
+			@media (max-width: 380px) {
+				flex-direction: column;
+				gap: 0;
+
+				span {
+					margin-inline-start: unset;
+					text-align: initial;
+				}
 			}
 		}
 	}
@@ -61,11 +64,6 @@
 	&.has-hidden-label {
 		li {
 			padding: clamp(10px, calc(1.7vw), 20px) clamp(20px, calc(1.7vw + 10px), 30px);
-
-			span {
-				margin-inline-start: unset;
-				text-align: left;
-			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #235 
Alternative to #239 

The PR uses separate content for screen reader and visual layout, so that Voiceover and NVDA will both read the entire content of the list item.

#### Home (no visible label)

```html
<ul>
	<li class="is-meta-post_title">
		<span class="screen-reader-text">Site title: <a href="http://localhost:8888/google-ventures/">GV (Google Ventures)</a></span>
		<span aria-hidden="true"><a href="http://localhost:8888/google-ventures/">GV (Google Ventures)</a></span>
	</li>
	<li class="is-meta-domain">
		<span class="screen-reader-text">URL: <a class="external-link" href="https://www.gv.com/" target="_blank" rel="noopener noreferrer">gv.com</a></span>
		<span aria-hidden="true"><a class="external-link" href="https://www.gv.com/" target="_blank" rel="noopener noreferrer">gv.com</a></span>
	</li>
	<li class="is-meta-category">
		<span class="screen-reader-text">Category: <a href="http://localhost:8888/category/business/" rel="tag">Business</a></span>
		<span aria-hidden="true"><a href="http://localhost:8888/category/business/" rel="tag">Business</a></span>
	</li>
</ul>
```

#### Single

```html
<ul>
	<li class="is-meta-country">
		<span class="screen-reader-text">Country: United States</span>
		<span aria-hidden="true"><strong>Country</strong><span>United States</span></span>
	</li>
	<li class="is-meta-category">
		<span class="screen-reader-text">Category: <a href="http://localhost:8888/category/business/" rel="tag">Business</a></span>
		<span aria-hidden="true"><strong>Category</strong><span><a href="http://localhost:8888/category/business/" rel="tag">Business</a></span></span>
	</li>
	<li class="is-meta-published">
		<span class="screen-reader-text">Published: September 2023</span>
		<span aria-hidden="true"><strong>Published</strong><span>September 2023</span></span>
	</li>
	<li class="is-meta-post_tag">
		<span class="screen-reader-text">Site tags: <a href="http://localhost:8888/tag/entrepreneur/" rel="tag">Entrepreneur</a>, <a href="http://localhost:8888/tag/startups/" rel="tag">Startups</a>, <a href="http://localhost:8888/tag/technology/" rel="tag">Technology</a></span>
		<span aria-hidden="true"><strong>Site tags</strong><span><a href="http://localhost:8888/tag/entrepreneur/" rel="tag">Entrepreneur</a>, <a href="http://localhost:8888/tag/startups/" rel="tag">Startups</a>, <a href="http://localhost:8888/tag/technology/" rel="tag">Technology</a></span></span>
	</li>
</ul>
```

Using specific screen reader content means we can avoid nested elements or visual space between elements, which cause screen readers to not read the list item as one.

Using NVDA where there are specific keys for navigating lists (L) and list items (I), the whole first item is read out when either key is used, eg. 'Country: United States' or 'Category: Creative (link)'. Full transcript from focusing list, then navigating items:

> main landmark    list  with 4 items  Country: Germany
Category:   Creative
Published: September 2023
Site tags:   Architecture  link    ,   Development  link    ,   Sustainability

Using Voiceover the nested anchor tags still require another keyboard navigation with right arrow, and are read individually, but the country and published items (without links) are read as one.

My understanding is that JAWS and NVDA cover the vast majority of screen reader users, so I think optimising for them is the best choice.

There are no visual changes.

### Testing

Use a screen reader to navigate the home and single site pages, checking how the screen reader interprets the meta list.

It should announce the list, then read each list item as 'label: value', and you should be able to navigate to the link within if appropriate (only country and published don't have links).

The label text should not be read twice.