### PR TITLE
Stop loading `wp-mediaelement` styles on the frontend

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -65,6 +65,7 @@ function enqueue_assets() {
 function maybe_dequeue_assets() {
 	if ( ! is_user_logged_in() ) {
 		wp_deregister_style( 'dashicons' );
+		wp_deregister_style( 'wp-mediaelement' );
 	}
 }
 


### PR DESCRIPTION
These styles also seem to have no use on the frontend, and are also being flagged under render blocking resources.