### PR TITLE
Query Filters: Replace overflow-y with overflow-x

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/style/style.scss
@@ -195,7 +195,7 @@ a:where(:not(.wp-element-button)):focus-visible {
 /* Scroll the filter bar smaller screens. */
 @media (max-width: 889px) {
 	.wporg-query-filters {
-		overflow-y: scroll;
+		overflow-x: scroll;
 		max-width: 100%;
 	}
 }


### PR DESCRIPTION
Related: https://github.com/WordPress/wporg-mu-plugins/pull/473

In showcase, the "Query Filters" only overflow horizontally ([noWrap is set](https://github.com/WordPress/wporg-showcase-2022/blob/main/source/wp-content/themes/wporg-showcase-2022/patterns/_site-grid-featured.php#L23)), so overflow-x is used in place of overflow-y.