### PR TITLE
Improve site meta list accessibility (V3)

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
@@ -99,19 +99,14 @@ function render( $attributes, $content, $block ) {
 		$value = get_value( $field['type'], $field['key'], $block->context['postId'] );
 
 		if ( ! empty( $value ) ) {
-			$value = wp_kses_post( $value );
-
 			$list_items[] = sprintf(
 				'<li class="is-meta-%1$s">
-					<span class="screen-reader-text">%2$s: %3$s</span>
-					<span aria-hidden="true">%4$s</span>
+					<strong%2$s>%3$s<span class="screen-reader-text">:</span></strong> %4$s
 				</li>',
 				$field['key'],
+				$show_label ? '' : ' class="screen-reader-text"',
 				$field['label'],
-				$value,
-				$show_label
-					? sprintf( '<strong>%1$s</strong><span>%2$s</span>', $field['label'], $value )
-					: $value,
+				wp_kses_post( $value )
 			);
 		}
 	}

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -10,37 +10,38 @@
 	}
 
 	li {
-		padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
-		border-bottom: 1px solid;
-		border-color: inherit;
+		position: relative;
+		padding-top: var(--wp--preset--spacing--10);
+		padding-right: var(--wp--preset--spacing--20);
+		padding-bottom: var(--wp--preset--spacing--10);
+		padding-left: calc(var(--wp--custom--wporg-site-meta-list--label--width) + var(--wp--preset--spacing--10));
+		text-align: end;
 
-		&:last-of-type {
-			border-bottom: none;
+		&:not(:last-of-type) {
+			border-bottom: 1px solid;
+			border-color: inherit;
 		}
 
-		span[aria-hidden="true"] {
-			display: flex;
-			gap: var(--wp--preset--spacing--10);
+		strong {
+			position: absolute;
+			left: var(--wp--preset--spacing--20);
+			top: var(--wp--preset--spacing--10);
+			max-width: calc(var(--wp--custom--wporg-site-meta-list--label--width));
+			font-weight: 400;
+			text-align: start;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		@media (max-width: 380px) {
+			text-align: start;
+			padding-left: var(--wp--preset--spacing--20);
 
 			strong {
-				flex-shrink: 0;
-				font-weight: 400;
-			}
-
-			span {
-				margin-inline-start: auto;
-				text-align: right;
-				color: var(--wp--preset--color--charcoal-3);
-			}
-
-			@media (max-width: 380px) {
-				flex-direction: column;
-				gap: 0;
-
-				span {
-					margin-inline-start: unset;
-					text-align: initial;
-				}
+				position: static;
+				display: block;
+				max-width: unset;
 			}
 		}
 	}
@@ -55,15 +56,10 @@
 		}
 	}
 
-	&.has-text-color {
-		li span {
-			color: inherit;
-		}
-	}
-
 	&.has-hidden-label {
 		li {
 			padding: clamp(10px, calc(1.7vw), 20px) clamp(20px, calc(1.7vw + 10px), 30px);
+			text-align: start;
 		}
 	}
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -34,6 +34,16 @@
 			white-space: nowrap;
 		}
 
+		[dir="rtl"] & {
+			padding-left: var(--wp--preset--spacing--20);
+			padding-right: calc(var(--wp--custom--wporg-site-meta-list--label--width) + var(--wp--preset--spacing--10));
+
+			strong {
+				left: unset;
+				right: var(--wp--preset--spacing--20);
+			}
+		}
+
 		@media (max-width: 380px) {
 			text-align: start;
 			padding-left: var(--wp--preset--spacing--20);
@@ -42,6 +52,10 @@
 				position: static;
 				display: block;
 				max-width: unset;
+			}
+
+			[dir="rtl"] & {
+				padding-right: var(--wp--preset--spacing--20);
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-showcase-2022/theme.json
+++ b/source/wp-content/themes/wporg-showcase-2022/theme.json
@@ -9,6 +9,11 @@
 					"width": "10px",
 					"radius": "20px"
 				}
+			},
+			"wporg-site-meta-list": {
+				"label": {
+					"width": "100px"
+				}
 			}
 		}
 	},


### PR DESCRIPTION
Fixes #235 

Use absolute position based layout, which avoids nested spans, so that screen readers read list item content as one. The `strong` tag is still necessary to be able to separate the parts.

Voiceover behaviour is returned to how it was originally. Each part of the list item requires an arrow navigation.

NVDA behaviour is pretty good; list items are read as one. I think the only nice-to-have would be for the entire for first item t be read when the list is navigated to, the actual behaviour is that the first tag with text content is read only, eg. 'Country:'. Transcript of navigating to list with 'L', and then items with 'I':

> main landmark    list  with 4 items  Country
Category  :  Community
Published  :  September 2023 
Site tags  :  Conservation  link    ,   Environment  link    ,   Nonprofit

There are no visual changes. The label has a fixed max-width, after which text will be ellipsized. The longest field name 'Published' fits comfortably, but a longer translated string could overflow. That's why I've avoided absolute positioning up til now; it's always brittle.

#### Home (no visual label)

```html
<ul>
	<li class="is-meta-post_title">
		<strong class="screen-reader-text">Site title<span class="screen-reader-text">:</span></strong> <a href="http://localhost:8888/meta-newsroom/">Meta Newsroom</a>
	</li>
	<li class="is-meta-domain">
		<strong class="screen-reader-text">URL<span class="screen-reader-text">:</span></strong> <a class="external-link" href="https://about.fb.com/news/" target="_blank" rel="noopener noreferrer">about.fb.com/news/</a>
	</li>
	<li class="is-meta-category">
		<strong class="screen-reader-text">Category<span class="screen-reader-text">:</span></strong> <a href="http://localhost:8888/category/business/" rel="tag">Business</a>
	</li>
</ul>
```

#### Single

```html
<ul>
	<li class="is-meta-author">
		<strong>Author<span class="screen-reader-text">:</span></strong> Meta
	</li>
	<li class="is-meta-country">
		<strong>Country<span class="screen-reader-text">:</span></strong> United States
	</li>
	<li class="is-meta-category">
		<strong>Category<span class="screen-reader-text">:</span></strong> <a href="http://localhost:8888/category/business/" rel="tag">Business</a>
	</li>
	<li class="is-meta-published">
		<strong>Published<span class="screen-reader-text">:</span></strong> April 2014
	</li>
	<li class="is-meta-post_tag">
		<strong>Site tags<span class="screen-reader-text">:</span></strong> <a href="http://localhost:8888/tag/news/" rel="tag">News</a>, <a href="http://localhost:8888/tag/social-media/" rel="tag">Social Media</a>, <a href="http://localhost:8888/tag/technology/" rel="tag">Technology</a>
	</li>
</ul>
```

### Testing

Use a screen reader to navigate the home and single site pages, checking how the screen reader interprets the meta list.

It should announce the list, then read each list item as 'label: value', and you should be able to navigate to the link within if appropriate (only country and published don't have links).