### PR TITLE
Remove `noreferrer` from Site Link and Site Meta List blocks.

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/site-link/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-link/index.php
@@ -39,7 +39,7 @@ function render( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'external-link' ) );
 	return sprintf(
-		'<p %1$s><a href="%2$s" target="_blank" rel="noopener noreferrer">%3$s</a></p>',
+		'<p %1$s><a href="%2$s" target="_blank" rel="noopener">%3$s</a></p>',
 		$wrapper_attributes,
 		esc_url( $domain ),
 		esc_html( $pretty_domain )

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
@@ -140,7 +140,7 @@ function get_value( $type, $key, $post_id ) {
 			$value = get_the_date( 'F Y', $post_id );
 		} else if ( 'domain' === $key ) {
 			// Domain uses shortcodes to output pretty format.
-			$value = do_shortcode( '<a class="external-link" href="[domain]" target="_blank" rel="noopener noreferrer">[pretty_domain]</a>' );
+			$value = do_shortcode( '<a class="external-link" href="[domain]" target="_blank" rel="noopener">[pretty_domain]</a>' );
 		} else if ( 'post_title' === $key ) {
 			$value = sprintf( '<a href="%s">%s</a>', get_permalink( $post_id ), get_the_title( $post_id ) );
 		}


### PR DESCRIPTION
Fixes #250 

Removed `noreferrer` from the link in the Site Link and Site Meta List blocks per feedback in #234 