### PR TITLE
Document meta: Improve the consistency of <title>s

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -406,15 +406,18 @@ function document_title( $parts ) {
 			$parts['title'] = sprintf( __( '%s - WordPress Showcase', 'wporg' ), $parts['title'] );
 		} elseif ( is_tag() ) {
 			// translators: %s: The name of the tag
-			$parts['title'] = sprintf( __( 'Sites tagged as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
+			$parts['title'] = sprintf( __( 'Showcase sites tagged as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
 		} elseif ( is_category() ) {
 			// translators: %s: The name of the tag
-			$parts['title'] = sprintf( __( 'Sites categorized as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
+			$parts['title'] = sprintf( __( 'Showcase sites categorized as "%s"', 'wporg' ), strtolower( $parts['title'] ) );
+		} elseif ( is_author() ) {
+			// translators: %s: Author name
+			$parts['title'] = sprintf( __( 'Showcase sites by %s', 'wporg' ), $parts['title'] );
 		} else {
 			$term_names = wp_list_pluck( get_applied_filter_list(), 'name' );
 			if ( $term_names ) {
-				// translators: %s list of terms used for filtering.
-				$parts['title'] = sprintf( __( 'Sites filtered by: %s', 'wporg' ), implode( ', ', $term_names ) );
+				// translators: %s: list of terms used for filtering
+				$parts['title'] = sprintf( __( 'Showcase sites filtered by: %s', 'wporg' ), implode( ', ', $term_names ) );
 			}
 		}
 


### PR DESCRIPTION
Fixes #243

This PR adds the demanded text to page `<title>` to improve consistency. [(Copy Ref)](https://github.com/WordPress/wporg-showcase-2022/issues/243#issuecomment-1766230654)

* `All Showcase Sites` is updated directly by changing its page title.

### Screenshots

| | |
| - | - |
| **Homepage: <br>Star-studded sites built with WordPress l WordPress.org** | <img width="551" alt="Screen Shot 2023-10-18 at 12 03 59 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/7cb608c8-5b35-4b73-ba8b-a8425e51934c"> |
| **Single post page: <br>{Single post title} – WordPress Showcase l WordPress.org** | <img width="514" alt="Screen Shot 2023-10-18 at 12 04 19 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/36713685-9fc7-4fb9-9acd-6d946a9aa575"> |
| **Category page: <br>Showcase sites categorized as “{category term}” l WordPress.org** | <img width="570" alt="Screen Shot 2023-10-18 at 12 05 25 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/d5870145-203b-4652-b453-2fd65904fa99"> |
| **Tag page: <br>Showcase sites tagged as “{tag term}” l WordPress.org** | <img width="566" alt="Screen Shot 2023-10-18 at 12 06 20 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/690e2478-2750-451c-aff5-bdd246c90227"> |
| **Search result page: <br>Showcase sites filtered by: {search term} l WordPress.org** | <img width="545" alt="Screen Shot 2023-10-18 at 12 07 08 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/839fcc0b-5ff7-461f-b9bf-636d0d5bdd71"> |
| **Author page: <br>Showcase sites by {author name} l WordPress.org** | <img width="468" alt="Screen Shot 2023-10-18 at 12 07 58 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/8c182cfd-e8da-4134-a22a-bddf4e364948">| 
| **Page post type: <br>{Page Title} l WordPress.org <br> {Page Title} l Page {current page #} of {total page #} l WordPress.org** | <img width="582" alt="Screen Shot 2023-10-18 at 1 03 33 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/e347d840-cee5-419d-96e2-930768e4715d"> |
| **Archive page: <br>All Showcase Sites l WordPress.org <br>All Showcase Sites l Page 2 of 13 l WordPress.org** | <img width="437" alt="Screen Shot 2023-10-18 at 12 31 12 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/8a57f714-1890-47b5-98df-a48b0dddd824"> <img width="520" alt="Screen Shot 2023-10-18 at 12 32 51 AM" src="https://github.com/WordPress/wporg-showcase-2022/assets/18050944/6fea6cb4-591b-4610-8e95-379d57d5d274"> |

