### PR TITLE
Use chevron icon for local nav mobile menu

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-dark.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-dark.php
@@ -11,7 +11,7 @@
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 	<!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"charcoal-1","textColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-front.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-front.php
@@ -15,5 +15,5 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->

--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav.php
@@ -11,7 +11,7 @@
 <!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 <!-- wp:site-title {"level":0,"fontSize":"small"} /-->
 
-	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","hasIcon":false,"layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
+	<!-- wp:navigation {"menuSlug":"showcase","textColor":"white","backgroundColor":"charcoal-1","icon":"menu","layout":{"type":"flex","orientation":"horizontal"},"style":{"spacing":{"blockGap":"24px"}},"fontSize":"small"} /-->
 <!-- /wp:wporg/local-navigation-bar -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"18px","bottom":"18px","left":"var:preset|spacing|edge-space","right":"var:preset|spacing|edge-space"}}},"backgroundColor":"white","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->


### PR DESCRIPTION
Changes the local navigation blocks to use the 'menu' (3 bar) icon on mobile, so that in conjunction with https://github.com/WordPress/wporg-mu-plugins/pull/480 the button changes from the word 'Menu' to a chevron icon.

### Screenshots

| State | Home | Single | Thanks |
|-|-|-|-|
| Closed | ![localhost_8888_(Samsung Galaxy S20 Ultra) (12)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/03b15549-6252-4a11-a39f-3bb2862d6339) | ![localhost_8888_meta-newsroom_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/3cbebe73-98f7-44da-9ba6-c962049b3ff2) | ![localhost_8888_submit-a-wordpress-site_thanks_(Samsung Galaxy S20 Ultra) (5)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/45babecf-c74f-4c40-a7d9-36e586b6ad43) |
| Open | ![localhost_8888_(Samsung Galaxy S20 Ultra) (13)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/b3ab3887-2543-4b2a-930a-7dee9b9885f4) | ![localhost_8888_meta-newsroom_(Samsung Galaxy S20 Ultra) (1)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/473d9b1e-c303-4f74-a1f7-1cc359fe4331) | ![localhost_8888_submit-a-wordpress-site_thanks_(Samsung Galaxy S20 Ultra) (6)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/b46e340c-268b-4cd3-b249-d1131f079078) |

### Testing
1. Ensure your mu-plugins is on https://github.com/WordPress/wporg-mu-plugins/pull/480
2. There are 3 different navs, so you need to test [Home](http://localhost:8888/), [Single](http://localhost:8888/meta-newsroom/), and [Thanks](http://localhost:8888/submit-a-wordpress-site/thanks/) pages
3. Simulate mobile size and check the menu icons when open and closed, a caret should be displayed for both