### PR TITLE
Remove unnecessary padding top and bottom

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-front.php
+++ b/source/wp-content/themes/wporg-showcase-2022/patterns/_nav-front.php
@@ -8,7 +8,7 @@
  */
 
 ?>
-<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space","top":"17px","bottom":"18px"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
+<!-- wp:wporg/local-navigation-bar {"backgroundColor":"charcoal-1","style":{"spacing":{"padding":{"right":"var:preset|spacing|edge-space","left":"var:preset|spacing|edge-space"}},"position":{"type":"sticky"},"elements":{"link":{"color":{"text":"var:preset|color|white"},":hover":{"color":{"text":"var:preset|color|white"}}}}},"textColor":"white","fontSize":"small"} -->
 	<!-- wp:group -->
 	<div class="wp-block-group">
 		<!-- wp:site-title {"level":1,"isLink":false,"fontSize":"small","fontFamily":"inter"} /-->


### PR DESCRIPTION
As discussed on https://github.com/WordPress/wporg-mu-plugins/pull/519, prefer to set this value as the default there, so removing the padding top and bottom here in the Showcase.

![image](https://github.com/WordPress/wporg-showcase-2022/assets/18050944/49e2ffff-06e9-4631-a2ea-4e5dfedd0347)

