### PR TITLE
Make site metadata accessible

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/index.php
@@ -100,9 +100,10 @@ function render( $attributes, $content, $block ) {
 
 		if ( ! empty( $value ) ) {
 			$list_items[] = sprintf(
-				'<li class="is-meta-%1$s">
-					<strong%2$s>%3$s</strong> %4$s
-				</li>',
+				'<tr class="is-meta-%1$s">
+					<th%2$s>%3$s</th>
+					<td>%4$s</td>
+				</tr>',
 				$field['key'],
 				$show_label ? '' : ' class="screen-reader-text"',
 				$field['label'],
@@ -114,7 +115,7 @@ function render( $attributes, $content, $block ) {
 	$class = $show_label ? '' : 'has-hidden-label';
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class ) );
 	return sprintf(
-		'<div %s><ul>%s</ul></div>',
+		'<div %s><table>%s</table></div>',
 		$wrapper_attributes,
 		join( '', $list_items )
 	);

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -2,9 +2,8 @@
 	margin-block-start: 0;
 
 	table,
-	tbody,
-	tr {
-		// Needed to pass border color down to `td` and `th`.
+	tbody {
+		// Needed to pass border color down to `tr`.
 		border-color: inherit;
 	}
 
@@ -13,15 +12,13 @@
 		padding: 0;
 		width: 100%;
 		border-spacing: 0;
+		border-collapse: collapse;
 	}
 
 	tr {
 		&:not(:last-of-type) {
-			th,
-			td {
-				border-bottom: 1px solid;
-				border-color: inherit;
-			}
+			border-bottom: 1px solid;
+			border-color: inherit;
 		}
 
 		th:not(.screen-reader-text),
@@ -48,10 +45,6 @@
 
 			th:not(.screen-reader-text) {
 				padding-bottom: 0;
-			}
-
-			&:not(:last-of-type) th {
-				border-bottom: none;
 			}
 
 			td {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -1,61 +1,57 @@
 .wp-block-wporg-site-meta-list {
 	margin-block-start: 0;
 
-	ul {
+	table {
 		margin: 0;
 		padding: 0;
-		list-style-type: none;
-		// Needed to pass border color down to `li`.
+		width: 100%;
+		// Needed to pass border color down to `td` and `th`.
 		border-color: inherit;
+		border-spacing: 0;
 	}
 
-	li {
-		position: relative;
-		padding-top: var(--wp--preset--spacing--10);
-		padding-right: var(--wp--preset--spacing--20);
-		padding-bottom: var(--wp--preset--spacing--10);
-		padding-left: calc(var(--wp--custom--wporg-site-meta-list--label--width) + var(--wp--preset--spacing--10));
-		text-align: end;
-
+	tr {
 		&:not(:last-of-type) {
-			border-bottom: 1px solid;
-			border-color: inherit;
+			th,
+			td {
+				border-bottom: 1px solid;
+				border-color: inherit;
+			}
 		}
 
-		strong {
-			position: absolute;
-			left: var(--wp--preset--spacing--20);
-			top: var(--wp--preset--spacing--10);
-			max-width: calc(var(--wp--custom--wporg-site-meta-list--label--width));
+		th:not(.screen-reader-text),
+		td {
+			padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
+		}
+
+		th {
 			font-weight: 400;
 			text-align: start;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			white-space: nowrap;
 		}
 
-		[dir="rtl"] & {
-			padding-left: var(--wp--preset--spacing--20);
-			padding-right: calc(var(--wp--custom--wporg-site-meta-list--label--width) + var(--wp--preset--spacing--10));
-
-			strong {
-				left: unset;
-				right: var(--wp--preset--spacing--20);
-			}
+		td {
+			text-align: end;
 		}
 
 		@media (max-width: 380px) {
-			text-align: start;
-			padding-left: var(--wp--preset--spacing--20);
+			display: block;
 
-			strong {
-				position: static;
+			th,
+			td {
 				display: block;
-				max-width: unset;
 			}
 
-			[dir="rtl"] & {
-				padding-right: var(--wp--preset--spacing--20);
+			th:not(.screen-reader-text) {
+				padding-bottom: 0;
+			}
+
+			&:not(:last-of-type) th {
+				border-bottom: none;
+			}
+
+			td {
+				text-align: start;
+				padding-top: 0;
 			}
 		}
 	}
@@ -71,7 +67,7 @@
 	}
 
 	&.has-hidden-label {
-		li {
+		td {
 			padding: clamp(10px, calc(1.7vw), 20px) clamp(20px, calc(1.7vw + 10px), 30px);
 			text-align: start;
 		}

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -1,12 +1,17 @@
 .wp-block-wporg-site-meta-list {
 	margin-block-start: 0;
 
+	table,
+	tbody,
+	tr {
+		// Needed to pass border color down to `td` and `th`.
+		border-color: inherit;
+	}
+
 	table {
 		margin: 0;
 		padding: 0;
 		width: 100%;
-		// Needed to pass border color down to `td` and `th`.
-		border-color: inherit;
 		border-spacing: 0;
 	}
 

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-meta-list/style.scss
@@ -16,6 +16,8 @@
 	}
 
 	tr {
+		vertical-align: baseline;
+
 		&:not(:last-of-type) {
 			border-bottom: 1px solid;
 			border-color: inherit;
@@ -23,16 +25,23 @@
 
 		th:not(.screen-reader-text),
 		td {
-			padding: var(--wp--preset--spacing--10) var(--wp--preset--spacing--20);
+			padding-top: var(--wp--preset--spacing--10);
+			padding-bottom: var(--wp--preset--spacing--10);
 		}
 
-		th {
+		th:not(.screen-reader-text) {
 			font-weight: 400;
 			text-align: start;
+			min-width: 100px;
+			padding-inline-start: var(--wp--preset--spacing--20);
+			// Keep a letter space between the label and the value.
+			// Required on smaller screens where they're more likely to collide.
+			padding-inline-end: 0.5em;
 		}
 
 		td {
 			text-align: end;
+			padding-inline-end: var(--wp--preset--spacing--20);
 		}
 
 		@media (max-width: 380px) {
@@ -45,11 +54,13 @@
 
 			th:not(.screen-reader-text) {
 				padding-bottom: 0;
+				padding-inline-end: var(--wp--preset--spacing--20);
 			}
 
 			td {
 				text-align: start;
 				padding-top: 0;
+				padding-inline-start: var(--wp--preset--spacing--20);
 			}
 		}
 	}

--- a/source/wp-content/themes/wporg-showcase-2022/theme.json
+++ b/source/wp-content/themes/wporg-showcase-2022/theme.json
@@ -9,11 +9,6 @@
 					"width": "10px",
 					"radius": "20px"
 				}
-			},
-			"wporg-site-meta-list": {
-				"label": {
-					"width": "100px"
-				}
 			}
 		}
 	},


### PR DESCRIPTION
Fixes #235 

After trying various CSS `display` layouts (flex, grid, table) and failing to make the content display well _and_ read well, this PR updates the markup to use a `table` so that screen reader users can use appropriate content navigation.

[This is the approach suggested by the A11y team](https://github.com/WordPress/wporg-showcase-2022/issues/235#issuecomment-1813474896).

There should be no visual change.

### Screenshots

#### Home

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_(Desktop) (2)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/675e652b-573a-4e08-82f9-017462996c9e) | ![localhost_8888_(iPad)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/8c41e084-5937-4ae2-9b96-3845706c2bc2) | ![localhost_8888_(Galaxy S5)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/cc50b3b8-d421-41d3-8463-c532556f3bdd) |

#### Single

| Desktop | Tablet | Mobile |
|-|-|-|
| ![localhost_8888_vogue_(Desktop)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/090b16a2-bfbf-46d8-83ef-4f3b171fd331) | ![localhost_8888_vogue_(iPad)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/cfafc820-852c-4165-80ea-5dc8eb355a3c) | ![localhost_8888_vogue_(Galaxy S5)](https://github.com/WordPress/wporg-showcase-2022/assets/1017872/67fda401-db27-4734-9092-cffdfd3cde35) |

## NVDA transcripts

### Home page

```
main landmark    list  with 1 item  table  with 3 rows and 2 columns  row 1  column 1  Site title
column 2  visited  link    Vogue
URL  row 2  link    vogue.com
Category  row 3  link    Publication
```

### Single site page

```
main landmark    table  with 4 rows and 2 columns  row 1  column 1  Author
column 2  Condé Nast
Country  row 2  United States
Category  row 3  link    Publication
Published  row 4  October 2019
```

## Testing

Browse the home page and single site pages using a screen reader, preferably JAWS or NVDA.
Focus the table using `t` then `Ctrl+Alt+Arrows` to navigate within the table.
Content should be read out with semantics as above.
Check for visual regressions, including various screen sizes and RTL.