### PR TITLE
Site Screenshot block: Update to support latest Interactivity API

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/package.json
+++ b/source/wp-content/themes/wporg-showcase-2022/package.json
@@ -23,8 +23,8 @@
 		"extends": "../../../../.stylelintrc"
 	},
 	"scripts": {
-		"build": "wp-scripts build",
-		"start": "wp-scripts start",
+		"build": "wp-scripts build --experimental-modules",
+		"start": "wp-scripts start --experimental-modules",
 		"lint:js": "wp-scripts lint-js src",
 		"lint:css": "wp-scripts lint-style *.css src/**/*.scss",
 		"format": "wp-scripts format src"

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/block.json
@@ -59,7 +59,7 @@
 	"usesContext": [ "postId" ],
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
-	"viewScript": "file:./view.js",
+	"viewModule": "file:./view.js",
 	"style": "file:./style-index.css",
 	"render": "file:../../src/site-screenshot/render.php"
 }

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/render.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/render.php
@@ -99,8 +99,8 @@ $encoded_state = wp_json_encode( $init_state );
 	<?php if ( $is_mshots ) : ?>
 		<div
 			class="wporg-site-screenshot__mshot-container"
-			data-wp-init="effects.init"
-			data-wp-watch="effects.update"
+			data-wp-init="callbacks.init"
+			data-wp-watch="callbacks.update"
 		>
 			<div class="wporg-site-screenshot__loader"></div>
 		</div>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/render.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/render.php
@@ -83,12 +83,12 @@ $init_state = [
 	'src' => esc_url( $screenshot ),
 	'alt' => the_title_attribute( array( 'echo' => false ) ),
 ];
-$encoded_state = wp_json_encode( [ 'wporg' => [ 'showcase' => [ 'screenshot' => $init_state ] ] ] );
+$encoded_state = wp_json_encode( $init_state );
 
 ?>
 <div
 	<?php echo get_block_wrapper_attributes( array( 'class' => $classname ) ); // phpcs:ignore ?>
-	data-wp-interactive
+	data-wp-interactive="<?php echo esc_attr( '{"namespace":"wporg/showcase/screenshot"}' ); ?>"
 	data-wp-context="<?php echo esc_attr( $encoded_state ); ?>"
 >
 	<?php if ( $has_link ) : ?>
@@ -98,8 +98,8 @@ $encoded_state = wp_json_encode( [ 'wporg' => [ 'showcase' => [ 'screenshot' => 
 	<?php if ( $is_mshots ) : ?>
 		<div
 			class="wporg-site-screenshot__mshot-container"
-			data-wp-init="effects.wporg.showcase.screenshot.init"
-			data-wp-effect="effects.wporg.showcase.screenshot.update"
+			data-wp-init="effects.init"
+			data-wp-watch="effects.update"
 		>
 			<div class="wporg-site-screenshot__loader"></div>
 		</div>

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/render.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/render.php
@@ -78,6 +78,7 @@ $init_state = [
 	'isMShots' => $is_mshots,
 	'isLazyLoad' => $is_lazyload,
 	'attempts' => 0,
+	'shouldRetry' => true,
 	'base64Image' => '',
 	'hasError' => false,
 	'src' => esc_url( $screenshot ),

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/render.php
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/render.php
@@ -100,9 +100,22 @@ $encoded_state = wp_json_encode( $init_state );
 		<div
 			class="wporg-site-screenshot__mshot-container"
 			data-wp-init="callbacks.init"
-			data-wp-watch="callbacks.update"
+			data-wp-class--has-loaded="state.hasLoaded"
 		>
-			<div class="wporg-site-screenshot__loader"></div>
+			<div
+				data-wp-class--wporg-site-screenshot__loader="!state.hasLoaded"
+				data-wp-class--wporg-site-screenshot__error="state.hasError"
+			>
+				<img
+					data-wp-bind--hidden="!state.base64Image"
+					data-wp-bind--alt="context.alt"
+					data-wp-bind--src="state.base64Image"
+				/>
+				<span
+					data-wp-bind--hidden="state.base64Image"
+					data-wp-text="context.alt"
+				></span>
+			</div>
 		</div>
 	<?php else : ?>
 		<img

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/style.scss
@@ -82,6 +82,11 @@
 		justify-content: center;
 		height: 100%;
 
+		img,
+		span {
+			display: none;
+		}
+
 		&::after {
 			content: "";
 			display: inline-block;

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/view.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/view.js
@@ -20,7 +20,7 @@ const { actions, state } = store( 'wporg/showcase/screenshot', {
 		},
 		get base64Image() {
 			return getContext().base64Image;
-		}
+		},
 	},
 	actions: {
 		increaseAttempts() {

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/view.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/view.js
@@ -2,7 +2,7 @@
 /**
  * WordPress dependencies
  */
-import { store as wpStore } from '@wordpress/interactivity';
+import { getContext, getElement, store } from '@wordpress/interactivity';
 
 /**
  * Module constants
@@ -10,134 +10,107 @@ import { store as wpStore } from '@wordpress/interactivity';
 const MAX_ATTEMPTS = 10;
 const RETRY_DELAY = 2000;
 
-/**
- * Helper to update the "attempts" value.
- *
- * @param {Object} store
- */
-function increaseAttempts( store ) {
-	store.context.wporg.showcase.screenshot.attempts++;
-}
+const { actions } = store( 'wporg/showcase/screenshot', {
+	actions: {
+		increaseAttempts() {
+			const context = getContext();
+			context.attempts++;
+		},
 
-/**
- * Helper to update the "shouldRetry" value.
- *
- * @param {boolean} value
- * @param {Object}  store
- */
-function setShouldRetry( value, store ) {
-	store.context.wporg.showcase.screenshot.shouldRetry = value;
-}
+		setShouldRetry( value ) {
+			const context = getContext();
+			context.shouldRetry = value;
+		},
 
-/**
- * Helper to update the "hasError" value.
- *
- * @param {boolean} value
- * @param {Object}  store
- */
-function setHasError( value, store ) {
-	store.context.wporg.showcase.screenshot.hasError = value;
-}
+		setHasError( value ) {
+			const context = getContext();
+			context.hasError = value;
+		},
 
-/**
- * Helper to update the "base64Image" value.
- *
- * @param {string} value
- * @param {Object} store
- */
-function setBase64Image( value, store ) {
-	store.context.wporg.showcase.screenshot.base64Image = value;
-}
+		setBase64Image( value ) {
+			const context = getContext();
+			context.base64Image = value;
+		},
 
-/**
- * Make a request to the mShots URL, update state values.
- *
- * @param {string} fullUrl
- * @param {Object} store
- */
-const fetchImage = async ( fullUrl, store ) => {
-	try {
-		const res = await fetch( fullUrl );
-		increaseAttempts( store );
+		*fetchImage( fullUrl ) {
+			try {
+				const res = yield fetch( fullUrl );
+				actions.increaseAttempts();
 
-		if ( res.redirected ) {
-			setShouldRetry( true, store );
-		} else if ( res.status === 200 && ! res.redirected ) {
-			const blob = await res.blob();
+				if ( res.redirected ) {
+					actions.setShouldRetry( true );
+				} else if ( res.status === 200 && ! res.redirected ) {
+					const blob = yield res.blob();
 
-			const reader = new FileReader();
-			reader.onload = ( event ) => {
-				setBase64Image( event.target.result, store );
-			};
-			reader.readAsDataURL( blob );
+					const value = yield new Promise( ( resolve ) => {
+						const reader = new FileReader();
+						reader.onloadend = () => resolve( reader.result );
+						reader.readAsDataURL( blob );
+					} );
 
-			setShouldRetry( false, store );
-		}
-	} catch ( error ) {
-		setHasError( true, store );
-		setShouldRetry( false, store );
-	}
-};
-
-wpStore( {
+					actions.setBase64Image( value );
+					actions.setShouldRetry( false );
+				}
+			} catch ( error ) {
+				actions.setHasError( true );
+				actions.setShouldRetry( false );
+			}
+		},
+	},
 	effects: {
-		wporg: {
-			showcase: {
-				screenshot: {
-					// Run on init, starts the image fetch process.
-					init: async ( store ) => {
-						const { context } = store;
-						const { base64Image, isMShots, src } = context.wporg.showcase.screenshot;
+		// Run on init, starts the image fetch process.
+		init: async () => {
+			const context = getContext();
+			const { base64Image, isMShots, src } = context;
+			// console.log( { base64Image, isMShots, src } );
 
-						if ( isMShots && ! base64Image ) {
-							// Initial fetch.
-							await fetchImage( src, store );
+			if ( isMShots && ! base64Image ) {
+				// Initial fetch.
+				await actions.fetchImage( src );
 
-							// Set up the function to retry every RETRY_DELAY (2 seconds).
-							const intervalId = setInterval(
-								async ( _context ) => {
-									const { attempts, base64Image: _base64Image, shouldRetry } = _context;
-									if ( shouldRetry ) {
-										await fetchImage( src, store );
-									}
-									if ( attempts >= MAX_ATTEMPTS ) {
-										clearInterval( intervalId );
-										if ( ! _base64Image ) {
-											setHasError( true, store );
-										}
-									}
-								},
-								RETRY_DELAY,
-								context.wporg.showcase.screenshot
-							);
+				// Set up the function to retry every RETRY_DELAY (2 seconds).
+				const intervalId = setInterval(
+					async ( _context ) => {
+						const { attempts, base64Image: _base64Image, shouldRetry } = _context;
+						if ( shouldRetry ) {
+							await actions.fetchImage( src );
+						}
+						if ( attempts >= MAX_ATTEMPTS ) {
+							clearInterval( intervalId );
+							if ( ! _base64Image ) {
+								actions.setHasError( true );
+							}
 						}
 					},
+					RETRY_DELAY,
+					context
+				);
+			}
+		},
 
-					// Run as an effect, when the context changes.
-					update: ( store ) => {
-						const { context, ref } = store;
-						const { alt, base64Image, hasError, isMShots } = context.wporg.showcase.screenshot;
+		// Run as an effect, when the context changes.
+		update: () => {
+			const context = getContext();
+			const { ref } = getElement();
+			const { alt, base64Image, hasError, isMShots } = context;
 
-						if ( ! isMShots ) {
-							return;
-						}
+			if ( ! isMShots ) {
+				return;
+			}
 
-						if ( hasError ) {
-							const spinner = ref.querySelector( 'div' );
-							spinner.classList.remove( 'wporg-site-screenshot__loader' );
-							spinner.classList.add( 'wporg-site-screenshot__error' );
-							spinner.innerText = alt;
-							ref.parentElement.classList.remove( 'has-loaded' );
-						} else if ( base64Image ) {
-							const img = document.createElement( 'img' );
-							img.src = base64Image;
-							img.alt = alt;
-							ref.replaceChildren( img );
-							ref.parentElement.classList.add( 'has-loaded' );
-						}
-					},
-				},
-			},
+			if ( hasError ) {
+				const spinner = ref.querySelector( 'div' );
+				spinner.classList.remove( 'wporg-site-screenshot__loader' );
+				spinner.classList.add( 'wporg-site-screenshot__error' );
+				spinner.innerText = alt;
+				ref.parentElement.classList.remove( 'has-loaded' );
+			} else if ( base64Image ) {
+				const img = document.createElement( 'img' );
+				img.src = base64Image;
+				img.alt = alt;
+				ref.replaceChildren( img );
+				ref.parentElement.classList.add( 'has-loaded' );
+			}
 		},
 	},
 } );

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/view.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/view.js
@@ -2,7 +2,7 @@
 /**
  * WordPress dependencies
  */
-import { getContext, getElement, store } from '@wordpress/interactivity';
+import { getContext, store } from '@wordpress/interactivity';
 
 /**
  * Module constants
@@ -20,6 +20,12 @@ const { actions, state } = store( 'wporg/showcase/screenshot', {
 		},
 		get base64Image() {
 			return getContext().base64Image;
+		},
+		get hasError() {
+			return getContext().hasError;
+		},
+		get hasLoaded() {
+			return state.base64Image || state.hasError;
 		},
 	},
 	actions: {
@@ -68,6 +74,7 @@ const { actions, state } = store( 'wporg/showcase/screenshot', {
 			}
 		},
 	},
+
 	callbacks: {
 		// Run on init, starts the image fetch process.
 		*init() {
@@ -88,30 +95,6 @@ const { actions, state } = store( 'wporg/showcase/screenshot', {
 						actions.setShouldRetry( false );
 					}
 				}
-			}
-		},
-
-		update() {
-			const context = getContext();
-			const { ref } = getElement();
-			const { alt, hasError, isMShots } = context;
-
-			if ( ! isMShots ) {
-				return;
-			}
-
-			if ( hasError ) {
-				const spinner = ref.querySelector( 'div' );
-				spinner.classList.remove( 'wporg-site-screenshot__loader' );
-				spinner.classList.add( 'wporg-site-screenshot__error' );
-				spinner.innerText = alt;
-				ref.parentElement.classList.remove( 'has-loaded' );
-			} else if ( state.base64Image ) {
-				const img = document.createElement( 'img' );
-				img.src = state.base64Image;
-				img.alt = alt;
-				ref.replaceChildren( img );
-				ref.parentElement.classList.add( 'has-loaded' );
 			}
 		},
 	},

--- a/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/view.js
+++ b/source/wp-content/themes/wporg-showcase-2022/src/site-screenshot/view.js
@@ -68,7 +68,7 @@ const { actions, state } = store( 'wporg/showcase/screenshot', {
 			}
 		},
 	},
-	effects: {
+	callbacks: {
 		// Run on init, starts the image fetch process.
 		*init() {
 			const { isMShots, src } = getContext();


### PR DESCRIPTION
**Merge alongside https://github.com/WordPress/wporg-mu-plugins/pull/561, so that production has current Gutenberg version.**

Update the dependencies so that we can use the `viewModule` block.json entry, which wp-scripts will correctly build as a module (required by the interactivity API script).

The updated wp-scripts requires a more modern node version, so I've also updated the version for this project to 20 (see https://github.com/WordPress/wporg-parent-2021/issues/122, we'll want to do this across all projects). I've pushed the package and node version updates to `main`, so this PR only contains the Interactivity API updates.

The changes for the Interactivity API are mostly following [the changelog recommendations](https://github.com/WordPress/gutenberg/discussions/52906#discussioncomment-7810998). The exception is the change to how the screenshots are rendered. Rather than directly manipulating the DOM, the new method uses a combination of directives and state values to show/hide the image once it's loaded. This is more in line with expected behavior from the Interactivity API.

Fixes #267.

**To test**

1. Update composer packages so you have the latest Gutenberg: `composer update`
2. Update node: `nvm install`
3. Update yarn deps: `yarn`
4. Build the theme: `yarn build:theme`
5. Start the env: `yarn wp-env start`
6. Click through the site, all the screenshots should show up correctly— if no local image is attached, there should be a loading spinner, and then load in the mshots image.