### PR TITLE
Conditionally send email on form submission

### DIFF
--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -36,8 +36,8 @@ add_filter( 'jetpack_related_posts_display_markup', __NAMESPACE__ . '\jetpack_re
 add_filter( 'jetpack_relatedposts_returned_results', __NAMESPACE__ . '\jetpack_related_posts_results', 10, 2 );
 add_filter( 'grunion_contact_form_redirect_url', __NAMESPACE__ . '\jetpack_redirect_submission_form' );
 
-// Don't send an email on contact for submission.
-add_filter( 'grunion_should_send_email', '__return_false' );
+// Conditionally send email on form submission.
+add_filter( 'grunion_should_send_email', __NAMESPACE__ . '\conditionally_send_email', 10, 2 );
 // Enable auto-fill using user information.
 add_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
 // Remove Jetpack CSS on frontend
@@ -648,4 +648,23 @@ function remove_featured_category_frontend( $terms, $post_id, $taxonomy ) {
 	}
 
 	return $terms;
+}
+
+/**
+ * Conditionally send email on form submission.
+ *
+ * @param boolean $send_email Whether to send an email.
+ * @param int $post_id The post ID.
+ * @return boolean
+ */
+function conditionally_send_email( $send_email, $post_id ) {
+	// Allow email for new site submission.
+	$feedback_meta = get_post_meta($post_id, '_feedback_akismet_values', true);
+	if ( is_array( $feedback_meta ) &&isset($feedback_meta['REQUEST_URI']) && 
+		'/showcase/submit-a-wordpress-site/' === $feedback_meta['REQUEST_URI']
+	) {
+		return true;
+	}
+
+    return false; // For all other forms, do not send email
 }

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -654,17 +654,18 @@ function remove_featured_category_frontend( $terms, $post_id, $taxonomy ) {
  * Conditionally send email on form submission.
  *
  * @param boolean $send_email Whether to send an email.
- * @param int $post_id The post ID.
+ * @param int     $post_id The post ID.
  * @return boolean
  */
 function conditionally_send_email( $send_email, $post_id ) {
 	// Allow email for new site submission.
-	$feedback_meta = get_post_meta($post_id, '_feedback_akismet_values', true);
-	if ( is_array( $feedback_meta ) &&isset($feedback_meta['REQUEST_URI']) && 
-		'/showcase/submit-a-wordpress-site/' === $feedback_meta['REQUEST_URI']
+	$feedback_meta = get_post_meta( $post_id, '_feedback_akismet_values', true );
+	if ( is_array( $feedback_meta ) &&
+		 isset( $feedback_meta['REQUEST_URI'] ) &&
+		 '/showcase/submit-a-wordpress-site/' === $feedback_meta['REQUEST_URI']
 	) {
 		return true;
 	}
 
-    return false; // For all other forms, do not send email
+	return false; // For all other forms, do not send email
 }

--- a/source/wp-content/themes/wporg-showcase-2022/functions.php
+++ b/source/wp-content/themes/wporg-showcase-2022/functions.php
@@ -36,8 +36,6 @@ add_filter( 'jetpack_related_posts_display_markup', __NAMESPACE__ . '\jetpack_re
 add_filter( 'jetpack_relatedposts_returned_results', __NAMESPACE__ . '\jetpack_related_posts_results', 10, 2 );
 add_filter( 'grunion_contact_form_redirect_url', __NAMESPACE__ . '\jetpack_redirect_submission_form' );
 
-// Conditionally send email on form submission.
-add_filter( 'grunion_should_send_email', __NAMESPACE__ . '\conditionally_send_email', 10, 2 );
 // Enable auto-fill using user information.
 add_filter( 'jetpack_auto_fill_logged_in_user', '__return_true' );
 // Remove Jetpack CSS on frontend
@@ -648,24 +646,4 @@ function remove_featured_category_frontend( $terms, $post_id, $taxonomy ) {
 	}
 
 	return $terms;
-}
-
-/**
- * Conditionally send email on form submission.
- *
- * @param boolean $send_email Whether to send an email.
- * @param int     $post_id The post ID.
- * @return boolean
- */
-function conditionally_send_email( $send_email, $post_id ) {
-	// Allow email for new site submission.
-	$feedback_meta = get_post_meta( $post_id, '_feedback_akismet_values', true );
-	if ( is_array( $feedback_meta ) &&
-		 isset( $feedback_meta['REQUEST_URI'] ) &&
-		 '/showcase/submit-a-wordpress-site/' === $feedback_meta['REQUEST_URI']
-	) {
-		return true;
-	}
-
-	return false; // For all other forms, do not send email
 }


### PR DESCRIPTION
Resolves #279 

Add a condition to automatically send an email after the new site submission form is submitted.

**How to Test**

1. Go to the page `/submit-a-wordpress-site`
2. Edit the page.
3. Under sidebar of the form block -> Change "Email address to send to" to your testing email address.
4. Submit the form.
5. Should receive the email immediately.
6. Other kinds of forms should not send emails on submission.