### PR TITLE
Actions: Update branch references from main to trunk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build and push to build branch.
 
 on:
   push:
-    branches: [main]
+    branches: [trunk]
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
-          ref: main
+          ref: trunk
 
       - name: Setup
         uses: WordPress/wporg-repo-tools/.github/actions/setup@trunk

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,7 +3,7 @@ name: Static Analysis (Linting)
 # This workflow is triggered on pushes to trunk, and any PRs.
 on:
   push:
-    branches: [main]
+    branches: [trunk]
   pull_request:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Node version is pinned in `.nvmrc` (20).
 
 ## Build & deploy
 
-`.github/workflows/build.yml` runs on every push to `main`: it strips the repo down to just the theme directory, appends the short SHA to the `Version:` header in `style.css`, and force-pushes the result to the `build` branch. Downstream consumers (and other wporg repos' Composer deps) track that branch — never commit to `build` directly.
+`.github/workflows/build.yml` runs on every push to `trunk`: it strips the repo down to just the theme directory, appends the short SHA to the `Version:` header in `style.css`, and force-pushes the result to the `build` branch. Downstream consumers (and other wporg repos' Composer deps) track that branch — never commit to `build` directly.
 
 ## Gotchas
 


### PR DESCRIPTION
The base branch was renamed from `main` to `trunk`, but the workflows still referenced the old name.

- `build.yml` — push trigger and the checkout `ref`
- `linters.yml` — push trigger (its comment already said trunk)
- `AGENTS.md` — the build/deploy note

Without this, neither workflow would run on pushes to `trunk`, so the `build` branch that downstream consumers track would go stale.

The `@trunk` refs on the `WordPress/wporg-repo-tools` actions point at that repo's own branch and are unchanged.

Worth double-checking outside the repo: that the default branch is set to `trunk` in repo settings, and that no branch protection rules or required status checks are still keyed to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpdzZqjYNCNxhF3hSXZ9AD